### PR TITLE
feat: Update mechanism inspirado no gsd-update + auditoria de comandos

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -28,6 +28,14 @@
             "command": "hooks/ensure-helper.sh"
           }
         ]
+      },
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "hooks/check-update.sh"
+          }
+        ]
       }
     ],
     "PreToolUse": [

--- a/README.md
+++ b/README.md
@@ -77,6 +77,25 @@ The helper is **optional** — every skill has a `bash`/`jq` fallback. Its
 absence only reduces precision (cost telemetry, calibration), it does
 not break the loop.
 
+### Updates
+
+The plugin checks for new SleepWell or helper binary releases once
+per session (in background, throttled to 24h). Available updates show
+up via `/sleepwell:sleepwell-update`.
+
+```
+/sleepwell:sleepwell-update              # see what's available
+/sleepwell:sleepwell-update --apply      # download helper update
+/sleepwell:sleepwell-update --helper-only
+/sleepwell:sleepwell-update --plugin-only
+```
+
+Disable the background check with `SLEEPWELL_SKIP_UPDATE_CHECK=1`.
+Adjust the TTL with `SLEEPWELL_UPDATE_TTL=<seconds>` (default 86400).
+
+> **Tip:** type `/sl` and press `Tab` in Claude Code to autocomplete the
+> long namespaced commands.
+
 ## Quick start
 
 ```

--- a/README.md
+++ b/README.md
@@ -92,6 +92,28 @@ up via `/sleepwell:sleepwell-update`.
 
 Disable the background check with `SLEEPWELL_SKIP_UPDATE_CHECK=1`.
 Adjust the TTL with `SLEEPWELL_UPDATE_TTL=<seconds>` (default 86400).
+Override the repo with `SLEEPWELL_UPDATE_REPO=<owner>/<name>`.
+
+To suppress notifications about the optional helper binary (e.g. you
+never want it installed), create a sentinel file:
+
+```bash
+mkdir -p ~/.config/sleepwell && touch ~/.config/sleepwell/no-helper
+```
+
+#### Manual smoke test
+
+To verify the update check works end-to-end:
+
+```bash
+rm -f ~/.cache/sleepwell/update.json
+bash hooks/check-update.sh
+sleep 3
+cat ~/.cache/sleepwell/update.json
+```
+
+You should see a valid JSON with `plugin_installed`, `plugin_latest`,
+`helper_installed`, `helper_latest` and `*_update_available` flags.
 
 > **Tip:** type `/sl` and press `Tab` in Claude Code to autocomplete the
 > long namespaced commands.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -92,6 +92,28 @@ disponíveis aparecem via `/sleepwell:sleepwell-update`.
 
 Desative o check em background com `SLEEPWELL_SKIP_UPDATE_CHECK=1`.
 Ajuste o TTL com `SLEEPWELL_UPDATE_TTL=<segundos>` (padrão 86400).
+Sobrescreva o repo com `SLEEPWELL_UPDATE_REPO=<owner>/<name>`.
+
+Para suprimir notificações sobre o binário helper opcional (caso
+você nunca queira tê-lo instalado), crie um arquivo sentinela:
+
+```bash
+mkdir -p ~/.config/sleepwell && touch ~/.config/sleepwell/no-helper
+```
+
+#### Smoke test manual
+
+Para validar o check de update ponta-a-ponta:
+
+```bash
+rm -f ~/.cache/sleepwell/update.json
+bash hooks/check-update.sh
+sleep 3
+cat ~/.cache/sleepwell/update.json
+```
+
+Deve gerar um JSON válido com `plugin_installed`, `plugin_latest`,
+`helper_installed`, `helper_latest` e flags `*_update_available`.
 
 > **Dica:** digite `/sl` e pressione `Tab` no Claude Code para
 > autocompletar os comandos longos namespaced.

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -77,6 +77,25 @@ O helper é **opcional** — toda skill tem fallback em `bash`/`jq`. A
 ausência dele só reduz precisão (telemetria de custo, calibração), não
 quebra o loop.
 
+### Atualizações
+
+O plugin verifica novas releases do SleepWell e do binário helper uma
+vez por sessão (em background, com throttling de 24h). Atualizações
+disponíveis aparecem via `/sleepwell:sleepwell-update`.
+
+```
+/sleepwell:sleepwell-update              # ver o que está disponível
+/sleepwell:sleepwell-update --apply      # baixa update do helper
+/sleepwell:sleepwell-update --helper-only
+/sleepwell:sleepwell-update --plugin-only
+```
+
+Desative o check em background com `SLEEPWELL_SKIP_UPDATE_CHECK=1`.
+Ajuste o TTL com `SLEEPWELL_UPDATE_TTL=<segundos>` (padrão 86400).
+
+> **Dica:** digite `/sl` e pressione `Tab` no Claude Code para
+> autocompletar os comandos longos namespaced.
+
 ## Início rápido
 
 ```

--- a/commands/sleepwell-update.md
+++ b/commands/sleepwell-update.md
@@ -1,0 +1,53 @@
+---
+description: Check for and apply available plugin and helper binary updates from GitHub Releases.
+argument-hint: "[--check] [--apply] [--helper-only] [--plugin-only]"
+---
+
+# /sleepwell:sleepwell-update
+
+Detects newer SleepWell plugin and helper binary releases on GitHub
+and offers to apply them. Reads cached state from
+`~/.cache/sleepwell/update.json` (refreshed at most every 24h by the
+SessionStart `check-update.sh` hook).
+
+## Behavior
+
+- `--check` (default if no arg): print what is available without
+  applying.
+- `--apply`: apply both plugin update (instructs `/plugin update sleepwell@sleepwell`)
+  and helper binary update (re-runs `scripts/install-helper.sh`).
+- `--plugin-only`: only the plugin update guidance.
+- `--helper-only`: only the helper binary download.
+
+## Output (example, --check)
+
+| Component | Installed | Latest | Update? |
+|---|---|---|---|
+| sleepwell plugin | v0.6.1 | v0.7.0 | yes — run /plugin update sleepwell@sleepwell |
+| sleepwell-helper | bin-v0.6.0 | bin-v0.6.1 | yes — run with --apply or --helper-only |
+
+If no updates, prints "Up-to-date" with both versions.
+
+## How it works
+
+1. Reads cached `~/.cache/sleepwell/update.json` written by the
+   SessionStart `check-update.sh` hook (refreshed every 24h).
+2. If cache is missing or stale, refreshes inline (synchronous, ~2s).
+3. For `--apply`: helper update is automatic via
+   `scripts/install-helper.sh --version <tag>`. Plugin update is shown
+   as instruction since `/plugin update` cannot be invoked from a slash
+   command body.
+
+## Escape hatch
+
+Set `SLEEPWELL_SKIP_UPDATE_CHECK=1` in your shell to disable the
+SessionStart background check. Manual invocation via this command
+still works.
+
+## Notes
+
+- Cache TTL configurable via `SLEEPWELL_UPDATE_TTL` (seconds).
+- The helper download uses the same flow as the bootstrap install
+  (GitHub Releases for `bin-v*` tags, platform auto-detection).
+- Plugin updates require Claude Code to reload plugins
+  (`/reload-plugins` or restart).

--- a/commands/sleepwell-update.md
+++ b/commands/sleepwell-update.md
@@ -14,10 +14,13 @@ SessionStart `check-update.sh` hook).
 
 - `--check` (default if no arg): print what is available without
   applying.
-- `--apply`: apply both plugin update (instructs `/plugin update sleepwell@sleepwell`)
-  and helper binary update (re-runs `scripts/install-helper.sh`).
-- `--plugin-only`: only the plugin update guidance.
-- `--helper-only`: only the helper binary download.
+- `--apply`: download the helper binary update automatically (via
+  `scripts/install-helper.sh`) and **print to the user** the
+  instruction to run `/plugin update sleepwell@sleepwell` followed by
+  `/reload-plugins`. The plugin update itself is **not** executed by
+  this command — only the helper binary download is automatic.
+- `--plugin-only`: print plugin update guidance only.
+- `--helper-only`: download/install helper binary only.
 
 ## Output (example, --check)
 
@@ -33,10 +36,29 @@ If no updates, prints "Up-to-date" with both versions.
 1. Reads cached `~/.cache/sleepwell/update.json` written by the
    SessionStart `check-update.sh` hook (refreshed every 24h).
 2. If cache is missing or stale, refreshes inline (synchronous, ~2s).
-3. For `--apply`: helper update is automatic via
-   `scripts/install-helper.sh --version <tag>`. Plugin update is shown
-   as instruction since `/plugin update` cannot be invoked from a slash
-   command body.
+3. With `--apply`:
+   - **Helper binary update is automatic**: invokes
+     `bash scripts/install-helper.sh --version <tag>`.
+   - **Plugin update is an instruction**: this command prints to the
+     user the message to run `/plugin update sleepwell@sleepwell` and
+     then `/reload-plugins` (or restart Claude Code) manually. Slash
+     commands cannot invoke `/plugin update` from their body.
+
+## Execution flow (for the agent)
+
+1. Read `~/.cache/sleepwell/update.json`. If missing or older than
+   `SLEEPWELL_UPDATE_TTL` seconds, run `bash hooks/check-update.sh`
+   synchronously and re-read after ~3s.
+2. Parse `plugin_update_available` and `helper_update_available`.
+3. Print a status table (Component | Installed | Latest | Update?).
+4. If `--apply` or `--helper-only` and helper update is available:
+   - Run `bash scripts/install-helper.sh --version "$helper_latest"`.
+   - Verify with `sleepwell-helper --version`.
+5. If `--apply` or `--plugin-only` and plugin update is available:
+   - **Print to user** (do not execute): "To complete the plugin
+     update, run `/plugin update sleepwell@sleepwell` and then
+     `/reload-plugins` (or restart Claude Code)."
+6. If no updates: print "Up-to-date".
 
 ## Escape hatch
 
@@ -44,10 +66,19 @@ Set `SLEEPWELL_SKIP_UPDATE_CHECK=1` in your shell to disable the
 SessionStart background check. Manual invocation via this command
 still works.
 
+To suppress helper-binary update notifications entirely (for users
+who never want the optional helper installed):
+
+```bash
+mkdir -p ~/.config/sleepwell && touch ~/.config/sleepwell/no-helper
+```
+
 ## Notes
 
 - Cache TTL configurable via `SLEEPWELL_UPDATE_TTL` (seconds).
+- Repo can be overridden via `SLEEPWELL_UPDATE_REPO=<owner>/<name>`;
+  otherwise it is parsed from `.claude-plugin/plugin.json` `.repository`.
 - The helper download uses the same flow as the bootstrap install
   (GitHub Releases for `bin-v*` tags, platform auto-detection).
 - Plugin updates require Claude Code to reload plugins
-  (`/reload-plugins` or restart).
+  (`/reload-plugins` or restart) — this command will not do it for you.

--- a/hooks/check-update.sh
+++ b/hooks/check-update.sh
@@ -24,21 +24,41 @@ HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
 ROOT="$(dirname "$HERE")"
 PLUGIN_VERSION=$(jq -r .version "$ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "0.0.0")
 
+# Resolve owner/repo: env override > plugin.json .repository > last-resort default.
+REPO_FROM_ENV="${SLEEPWELL_UPDATE_REPO:-}"
+if [ -n "$REPO_FROM_ENV" ]; then
+  REPO_SLUG="$REPO_FROM_ENV"
+else
+  repo_url=$(jq -r '.repository // empty' "$ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "")
+  REPO_SLUG=$(echo "$repo_url" | sed -E 's#^https?://github.com/([^/]+/[^/]+).*#\1#' | sed -E 's/\.git$//')
+fi
+[ -z "$REPO_SLUG" ] && REPO_SLUG="FelipeOFF/sleepwell"
+
+# Helper opt-out: persistent sentinel suppresses helper notifications.
+HELPER_OPTOUT_FILE="${XDG_CONFIG_HOME:-$HOME/.config}/sleepwell/no-helper"
+
 # Helper version: prefer installed binary's --version output; else "none".
 HELPER_BIN_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/sleepwell/bin"
 HELPER_BIN="$HELPER_BIN_DIR/sleepwell-helper"
-[ -x "$HELPER_BIN" ] && HELPER_VERSION=$("$HELPER_BIN" --version 2>/dev/null | awk '{print $2}') || HELPER_VERSION="none"
+if [ -f "$HELPER_OPTOUT_FILE" ]; then
+  HELPER_VERSION="opted-out"
+else
+  [ -x "$HELPER_BIN" ] && HELPER_VERSION=$("$HELPER_BIN" --version 2>/dev/null | awk '{print $2}') || HELPER_VERSION="none"
+fi
 
 # Background fetch — never blocks startup.
 (
+  # Guard: jq is required for the JSON parsing below.
+  command -v jq >/dev/null || exit 0
+
   mkdir -p "$CACHE_DIR"
   latest_plugin=""
   latest_helper=""
   if command -v gh >/dev/null 2>&1; then
-    latest_plugin=$(gh api repos/FelipeOFF/sleepwell/releases --jq '[.[] | select(.tag_name | startswith("v"))][0].tag_name // empty' 2>/dev/null || true)
-    latest_helper=$(gh api repos/FelipeOFF/sleepwell/releases --jq '[.[] | select(.tag_name | startswith("bin-v"))][0].tag_name // empty' 2>/dev/null || true)
+    latest_plugin=$(timeout 8 gh api "repos/$REPO_SLUG/releases" --jq '[.[] | select(.tag_name | startswith("v"))][0].tag_name // empty' 2>/dev/null || true)
+    latest_helper=$(timeout 8 gh api "repos/$REPO_SLUG/releases" --jq '[.[] | select(.tag_name | startswith("bin-v"))][0].tag_name // empty' 2>/dev/null || true)
   elif command -v curl >/dev/null 2>&1; then
-    json=$(curl -fsSL --max-time 8 "https://api.github.com/repos/FelipeOFF/sleepwell/releases" 2>/dev/null || echo "[]")
+    json=$(curl -fsSL --max-time 8 "https://api.github.com/repos/$REPO_SLUG/releases" 2>/dev/null || echo "[]")
     latest_plugin=$(printf '%s' "$json" | jq -r '[.[] | select(.tag_name | startswith("v"))][0].tag_name // empty' 2>/dev/null || true)
     latest_helper=$(printf '%s' "$json" | jq -r '[.[] | select(.tag_name | startswith("bin-v"))][0].tag_name // empty' 2>/dev/null || true)
   fi
@@ -59,13 +79,16 @@ HELPER_BIN="$HELPER_BIN_DIR/sleepwell-helper"
   [ -n "$lp" ] && semver_gt "$lp" "$PLUGIN_VERSION" && plugin_update=true
 
   helper_update=false
-  if [ -n "$lh" ] && [ "$HELPER_VERSION" != "none" ]; then
+  if [ "$HELPER_VERSION" = "opted-out" ]; then
+    helper_update=false
+  elif [ -n "$lh" ] && [ "$HELPER_VERSION" != "none" ]; then
     semver_gt "$lh" "$HELPER_VERSION" && helper_update=true
   elif [ -n "$lh" ] && [ "$HELPER_VERSION" = "none" ]; then
     helper_update=true
   fi
 
-  cat > "$CACHE_FILE.tmp" <<JSON
+  tmp="$CACHE_FILE.$$.tmp"
+  cat > "$tmp" <<JSON
 {
   "plugin_installed": "$PLUGIN_VERSION",
   "plugin_latest": "${latest_plugin:-unknown}",
@@ -77,7 +100,7 @@ HELPER_BIN="$HELPER_BIN_DIR/sleepwell-helper"
   "checked_at_iso": "$(date -u +%FT%TZ)"
 }
 JSON
-  mv "$CACHE_FILE.tmp" "$CACHE_FILE"
+  mv "$tmp" "$CACHE_FILE"
 ) >/dev/null 2>&1 &
 disown 2>/dev/null || true
 exit 0

--- a/hooks/check-update.sh
+++ b/hooks/check-update.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# check-update.sh — SessionStart hook of the sleepwell plugin.
+# Checks GitHub for newer plugin or helper releases (best-effort, in background).
+# Writes a sentinel JSON cache to ~/.cache/sleepwell/update.json that
+# /sleepwell:sleepwell-update reads. Never blocks the session.
+set -u
+
+# Escape hatch.
+[ "${SLEEPWELL_SKIP_UPDATE_CHECK:-0}" = "1" ] && exit 0
+
+CACHE_DIR="${XDG_CACHE_HOME:-$HOME/.cache}/sleepwell"
+CACHE_FILE="$CACHE_DIR/update.json"
+TTL_SECS=${SLEEPWELL_UPDATE_TTL:-86400}  # 24h default
+
+# Skip if cache is fresh.
+if [ -f "$CACHE_FILE" ]; then
+  ts=$(jq -r '.checked_at_unix // 0' "$CACHE_FILE" 2>/dev/null || echo 0)
+  now=$(date +%s)
+  [ $((now - ts)) -lt "$TTL_SECS" ] && exit 0
+fi
+
+# Resolve plugin root and current versions.
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]:-$0}")" && pwd)"
+ROOT="$(dirname "$HERE")"
+PLUGIN_VERSION=$(jq -r .version "$ROOT/.claude-plugin/plugin.json" 2>/dev/null || echo "0.0.0")
+
+# Helper version: prefer installed binary's --version output; else "none".
+HELPER_BIN_DIR="${XDG_DATA_HOME:-$HOME/.local/share}/sleepwell/bin"
+HELPER_BIN="$HELPER_BIN_DIR/sleepwell-helper"
+[ -x "$HELPER_BIN" ] && HELPER_VERSION=$("$HELPER_BIN" --version 2>/dev/null | awk '{print $2}') || HELPER_VERSION="none"
+
+# Background fetch — never blocks startup.
+(
+  mkdir -p "$CACHE_DIR"
+  latest_plugin=""
+  latest_helper=""
+  if command -v gh >/dev/null 2>&1; then
+    latest_plugin=$(gh api repos/FelipeOFF/sleepwell/releases --jq '[.[] | select(.tag_name | startswith("v"))][0].tag_name // empty' 2>/dev/null || true)
+    latest_helper=$(gh api repos/FelipeOFF/sleepwell/releases --jq '[.[] | select(.tag_name | startswith("bin-v"))][0].tag_name // empty' 2>/dev/null || true)
+  elif command -v curl >/dev/null 2>&1; then
+    json=$(curl -fsSL --max-time 8 "https://api.github.com/repos/FelipeOFF/sleepwell/releases" 2>/dev/null || echo "[]")
+    latest_plugin=$(printf '%s' "$json" | jq -r '[.[] | select(.tag_name | startswith("v"))][0].tag_name // empty' 2>/dev/null || true)
+    latest_helper=$(printf '%s' "$json" | jq -r '[.[] | select(.tag_name | startswith("bin-v"))][0].tag_name // empty' 2>/dev/null || true)
+  fi
+
+  # Strip prefixes for comparison.
+  lp=${latest_plugin#v}
+  lh=${latest_helper#bin-v}
+
+  # Decide if updates are available (semver-ish lex compare).
+  semver_gt() {
+    # returns 0 if $1 > $2 by semver
+    [ "$1" = "$2" ] && return 1
+    higher=$(printf '%s\n%s\n' "$1" "$2" | sort -V | tail -1)
+    [ "$higher" = "$1" ]
+  }
+
+  plugin_update=false
+  [ -n "$lp" ] && semver_gt "$lp" "$PLUGIN_VERSION" && plugin_update=true
+
+  helper_update=false
+  if [ -n "$lh" ] && [ "$HELPER_VERSION" != "none" ]; then
+    semver_gt "$lh" "$HELPER_VERSION" && helper_update=true
+  elif [ -n "$lh" ] && [ "$HELPER_VERSION" = "none" ]; then
+    helper_update=true
+  fi
+
+  cat > "$CACHE_FILE.tmp" <<JSON
+{
+  "plugin_installed": "$PLUGIN_VERSION",
+  "plugin_latest": "${latest_plugin:-unknown}",
+  "plugin_update_available": $plugin_update,
+  "helper_installed": "$HELPER_VERSION",
+  "helper_latest": "${latest_helper:-unknown}",
+  "helper_update_available": $helper_update,
+  "checked_at_unix": $(date +%s),
+  "checked_at_iso": "$(date -u +%FT%TZ)"
+}
+JSON
+  mv "$CACHE_FILE.tmp" "$CACHE_FILE"
+) >/dev/null 2>&1 &
+disown 2>/dev/null || true
+exit 0

--- a/hooks/ensure-helper.sh
+++ b/hooks/ensure-helper.sh
@@ -20,10 +20,4 @@ INSTALL_SH="$ROOT/scripts/install-helper.sh"
 # Detach. SessionStart should not delay startup.
 disown 2>/dev/null || true
 
-# Trigger background update check (idempotent, throttled by TTL).
-if [ -x "$ROOT/hooks/check-update.sh" ]; then
-  bash "$ROOT/hooks/check-update.sh" >/dev/null 2>&1 &
-  disown 2>/dev/null || true
-fi
-
 exit 0

--- a/hooks/ensure-helper.sh
+++ b/hooks/ensure-helper.sh
@@ -19,4 +19,11 @@ INSTALL_SH="$ROOT/scripts/install-helper.sh"
 
 # Detach. SessionStart should not delay startup.
 disown 2>/dev/null || true
+
+# Trigger background update check (idempotent, throttled by TTL).
+if [ -x "$ROOT/hooks/check-update.sh" ]; then
+  bash "$ROOT/hooks/check-update.sh" >/dev/null 2>&1 &
+  disown 2>/dev/null || true
+fi
+
 exit 0


### PR DESCRIPTION
## Summary

Implementa um mecanismo de atualização ao estilo `gsd-update` para o
SleepWell, complementado por auditoria de segurança e melhorias de DX
recomendadas pelo Council.

### Update mechanism

- `hooks/check-update.sh` (novo SessionStart hook) — checa GitHub Releases
  em background, com TTL de 24h, e escreve `~/.cache/sleepwell/update.json`
  com `plugin_installed`, `plugin_latest`, `plugin_update_available`,
  `helper_installed`, `helper_latest`, `helper_update_available`,
  `checked_at_unix`, `checked_at_iso`. Nunca bloqueia o startup.
- `commands/sleepwell-update.md` (novo) — `--check` (default) / `--apply` /
  `--helper-only` / `--plugin-only`. Lê o cache; se ausente/stale, refaz
  inline.
- `hooks/ensure-helper.sh` — agora aciona `check-update.sh` em background
  ao final, como fallback caso o segundo SessionStart entry não rode.
- `.claude-plugin/plugin.json` — segundo SessionStart entry registrando
  `check-update.sh`.

### DX improvements (Council)

- README e README.pt-BR ganham seção "Updates / Atualizações" com exemplos.
- Adicionada dica `> Tip: type /sl + Tab` para autocomplete no CC, evitando
  digitar o prefixo namespaced inteiro.

### Security audit (Critic)

- `grep -rn 'eval\b|read -r'` em skills/commands/hooks/scripts.
- Zero `eval` shell encontrado (matches são identificadores `last_eval`,
  `sleepwell-evaluator`, etc).
- `read -r` aparece 3x, todos sobre input confiável (JSONL local,
  output de `find` em paths do plugin). Sem substituição necessária.

### Escape hatches

- `SLEEPWELL_SKIP_UPDATE_CHECK=1` desabilita o background check.
- `SLEEPWELL_UPDATE_TTL=<seconds>` ajusta a janela (default 86400s = 24h).

## Changes

- 3 commits atômicos (e0834b2, 7903e7a, c8851bf).
- Novo hook executável + novo command + plug no plugin.json.
- README EN + PT-BR em sincronia.
- Smoke: \`bash hooks/check-update.sh\` cria o JSON de cache válido sem
  bloquear.

## Test plan

- [ ] CI verde (rust + plugin manifest + shellcheck).
- [ ] \`bash -n hooks/*.sh && bash -n scripts/*.sh\`.
- [ ] \`python3 -c "import json; json.load(open('.claude-plugin/plugin.json'))"\`.
- [ ] Manual: deletar \`~/.cache/sleepwell/update.json\`, abrir nova
      sessão CC, conferir que o JSON aparece em ~5s sem travar startup.
- [ ] Manual: \`/sleepwell:sleepwell-update\` lista versões corretas.
- [ ] Manual: \`SLEEPWELL_SKIP_UPDATE_CHECK=1\` bypassa a checagem.

## Council validation

Decisão de NÃO refatorar parsing/sintaxe dos comandos (3 das 4 vozes
convergiram). Aspas funcionam porque \`\${ARGUMENTS}\` é string crua no
input do CC, não shell. Refator quebraria v0.6.1 sem ganho.

A dor real era descoberta do prefixo namespaced longo — resolvida pela
dica do Tab.
