### PR TITLE
feat: Self-heal recovery + multi-agent team workflow (sleepwell-team)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -106,4 +106,5 @@ target/
 
 
 # sleepwell loop state
-.sleepwell/
+.sleepwell/*
+!.sleepwell/team.config.example.yaml

--- a/.sleepwell/team.config.example.yaml
+++ b/.sleepwell/team.config.example.yaml
@@ -5,7 +5,11 @@ review:
   enabled: true
   agent: general-purpose      # or named subagent_type
   max_rounds: 2
-  block_on_severity: high     # any | medium | high | none
+  block_on_severity: high     # any | low | medium | high | none
+                              # any  = any comment blocks (alias of low)
+                              # low  = block on low+ (everything except none)
+                              # high = block only on high severity (default)
+                              # none = never block (review is advisory)
   scope: changed-files        # changed-files | full-pr | branch-vs-base
 
 fix:

--- a/.sleepwell/team.config.example.yaml
+++ b/.sleepwell/team.config.example.yaml
@@ -1,0 +1,38 @@
+# .sleepwell/team.config.yaml — multi-agent team workflow defaults.
+# Copy to .sleepwell/team.config.yaml in your project to customize.
+
+review:
+  enabled: true
+  agent: general-purpose      # or named subagent_type
+  max_rounds: 2
+  block_on_severity: high     # any | medium | high | none
+  scope: changed-files        # changed-files | full-pr | branch-vs-base
+
+fix:
+  enabled: true
+  agent: general-purpose
+  reply_to_threads: true      # post replies on resolved review threads
+
+ci:
+  poll_interval_secs: 30
+  max_wait_minutes: 30
+  required_checks: []         # empty = auto-detect from branch protection
+  fail_fast: true             # abort on first required check failure
+
+merge:
+  strategy: squash            # squash | merge | rebase
+  delete_branch: true
+  auto_merge: false           # true = enable GitHub auto-merge instead of waiting locally
+
+post_merge:
+  # List of actions executed in order after merge succeeds.
+  # Each action: type + params. Types built-in:
+  #   - dispatch_workflow: triggers a GH Actions workflow_dispatch
+  #   - run_command: invokes a /sleepwell:* command
+  #   - shell: runs a shell command (allowlisted)
+  #   - none: explicit no-op
+  - type: none
+  # Example for sleepwell self-development:
+  # - type: dispatch_workflow
+  #   workflow: bump-version.yml
+  #   inputs: { bump: patch }

--- a/README.md
+++ b/README.md
@@ -115,6 +115,23 @@ cat ~/.cache/sleepwell/update.json
 You should see a valid JSON with `plugin_installed`, `plugin_latest`,
 `helper_installed`, `helper_latest` and `*_update_available` flags.
 
+### Recovery
+
+If `/sleepwell:*` commands disappear from Claude Code (typically after a CC
+update or third-party tool that touches `~/.claude/plugins/`), the cache
+directory may have been removed while `installed_plugins.json` still
+references it. Recover with:
+
+```bash
+# From any terminal (does not require sleepwell to be loaded):
+bash <(curl -fsSL https://raw.githubusercontent.com/FelipeOFF/sleepwell/main/scripts/restore-plugin-cache.sh)
+
+# Or from inside Claude Code (if doctor still works):
+/sleepwell:sleepwell-doctor --restore-cache
+```
+
+After restore, run `/reload-plugins` in Claude Code.
+
 > **Tip:** type `/sl` and press `Tab` in Claude Code to autocomplete the
 > long namespaced commands.
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,25 @@ After restore, run `/reload-plugins` in Claude Code.
 | `radical` | Subsystem rewrites | Allows breaking and rebuilding; higher risk |
 | `wave` | Multi-agent collaboration (experimental) | Propose → critique → consolidate per iteration |
 
+## Team workflow (multi-agent)
+
+For end-to-end automation — implement → PR → review → fix → CI → merge — use:
+
+```
+/sleepwell:sleepwell-team-fix "implement OAuth2 with PKCE for the auth module" --mode build --max-iter 8 --max-review-rounds 2
+```
+
+This spawns 4 coordinated agents:
+
+| Agent | Role |
+|---|---|
+| Implementer | runs the standard sleepwell loop until done |
+| Reviewer | inspects the PR diff, posts line-level comments via gh api |
+| Fixer | applies fixes for each review comment, replies on threads |
+| CI-Watcher | polls gh pr checks until green or timeout |
+
+Configurable via `.sleepwell/team.config.yaml` (copy from `team.config.example.yaml`). Post-merge actions are flexible: dispatch a workflow, run another sleepwell command, or no-op for teams without a release step. See [`lib/team-workflow.md`](lib/team-workflow.md).
+
 ## Options
 
 ```

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -162,6 +162,25 @@ Depois de restaurar, rode `/reload-plugins` no Claude Code.
 | `radical` | Reescritas de subsistema | Permite quebrar e reconstruir; risco maior |
 | `wave` | Colaboração multi-agent (experimental) | Propõe → critica → consolida por iteração |
 
+## Team workflow (multi-agent)
+
+Para automação ponta-a-ponta — implement → PR → review → fix → CI → merge — use:
+
+```
+/sleepwell:sleepwell-team-fix "implementa OAuth2 com PKCE no módulo de auth" --mode build --max-iter 8 --max-review-rounds 2
+```
+
+Esse comando dispara 4 agentes coordenados:
+
+| Agente | Papel |
+|---|---|
+| Implementer | executa o sleepwell loop padrão até concluir |
+| Reviewer | inspeciona o diff do PR e posta comentários line-level via gh api |
+| Fixer | aplica correções para cada comentário e responde nas threads |
+| CI-Watcher | faz polling em gh pr checks até verde ou timeout |
+
+Configurável via `.sleepwell/team.config.yaml` (copie de `team.config.example.yaml`). As ações pós-merge são flexíveis: dispara um workflow, roda outro comando sleepwell, ou no-op para times sem release automatizado. Veja [`lib/team-workflow.md`](lib/team-workflow.md).
+
 ## Opções
 
 ```

--- a/README.pt-BR.md
+++ b/README.pt-BR.md
@@ -115,6 +115,23 @@ cat ~/.cache/sleepwell/update.json
 Deve gerar um JSON válido com `plugin_installed`, `plugin_latest`,
 `helper_installed`, `helper_latest` e flags `*_update_available`.
 
+### Recovery
+
+Se os comandos `/sleepwell:*` sumirem do Claude Code (tipicamente após
+um update do CC ou ferramenta de terceiros que mexe em
+`~/.claude/plugins/`), o diretório de cache pode ter sido removido
+enquanto `installed_plugins.json` ainda o referencia. Recupere com:
+
+```bash
+# A partir de qualquer terminal (não requer o sleepwell carregado):
+bash <(curl -fsSL https://raw.githubusercontent.com/FelipeOFF/sleepwell/main/scripts/restore-plugin-cache.sh)
+
+# Ou de dentro do Claude Code (se o doctor ainda funcionar):
+/sleepwell:sleepwell-doctor --restore-cache
+```
+
+Depois de restaurar, rode `/reload-plugins` no Claude Code.
+
 > **Dica:** digite `/sl` e pressione `Tab` no Claude Code para
 > autocompletar os comandos longos namespaced.
 

--- a/commands/sleepwell-doctor.md
+++ b/commands/sleepwell-doctor.md
@@ -1,6 +1,6 @@
 ---
 description: Diagnoses the sleepwell environment, checks the sleepwell-helper binary, and (re)installs if necessary.
-argument-hint: "[--reinstall] [--version <tag>] [--dest <dir>]"
+argument-hint: "[--reinstall] [--version <tag>] [--dest <dir>] [--restore-cache]"
 ---
 
 # /sleepwell:sleepwell-doctor
@@ -10,6 +10,15 @@ installed for the current platform.
 
 ## Steps
 
+0. **Pre-check cache integrity**. Read
+   `~/.claude/plugins/installed_plugins.json` and locate any
+   `sleepwell@*` entry. For each entry verify that
+   `<installPath>/.claude-plugin/plugin.json` exists and that
+   `<installPath>/commands/` is non-empty. If either is missing or
+   empty, the cache directory was wiped (typically by a Claude Code
+   update or by a third-party tool that touches `~/.claude/plugins/`).
+   Suggest re-running with `--restore-cache` (or invoking
+   `bash scripts/restore-plugin-cache.sh` directly from a terminal).
 1. **Detect platform** (OS + arch).
 2. **Check `sleepwell-helper`** in order:
    - `$XDG_DATA_HOME/sleepwell/bin/sleepwell-helper` (Linux/macOS)
@@ -29,11 +38,17 @@ installed for the current platform.
 - `--reinstall` — forces redownload even if binary is present.
 - `--version <tag>` — installs a specific version (e.g.: `bin-v0.5.0`).
 - `--dest <dir>` — alternative installation directory.
+- `--restore-cache` — invokes `bash scripts/restore-plugin-cache.sh` to
+  re-clone the plugin cache directory when it has been removed while
+  `installed_plugins.json` still references it. Show the script output
+  inline. After it completes, instruct the user to run
+  `/reload-plugins` in Claude Code.
 
 ## Output
 
 ```
 Platform:           darwin / aarch64
+cache:              ✓ valid (15 commands) at ~/.claude/plugins/cache/sleepwell/sleepwell/0.7.0
 sleepwell-helper:   ✓ installed (v0.5.0) at ~/.local/share/sleepwell/bin/sleepwell-helper
 git:                ✓ 2.45.1
 gh:                 ✓ 2.45.0 (authenticated as user@example.com)
@@ -41,6 +56,12 @@ jq:                 ✓ 1.7
 verify_cmds:        ⚠ partial — typecheck=auto, test=npm test, lint=missing
 hooks:              ✓ block-push.sh, scope-guard.sh, ensure-helper.sh executable
 state schema:       ✓ v3
+```
+
+When the cache is broken the line becomes:
+
+```
+cache:              ✗ broken — run /sleepwell:sleepwell-doctor --restore-cache
 ```
 
 ## Behavior by OS

--- a/commands/sleepwell-doctor.md
+++ b/commands/sleepwell-doctor.md
@@ -44,6 +44,27 @@ installed for the current platform.
   inline. After it completes, instruct the user to run
   `/reload-plugins` in Claude Code.
 
+### Flag interaction: `--restore-cache` × `--reinstall`
+
+The two flags address different artefacts and **can be combined**:
+
+- `--restore-cache` recovers the **plugin cache directory** (skill markdown,
+  commands, scripts) at `~/.claude/plugins/cache/...`. Without it the
+  doctor itself may fail to reach helper scripts.
+- `--reinstall` redownloads the **`sleepwell-helper` binary** under
+  `~/.local/share/sleepwell/bin/` (or platform equivalent).
+
+When both are passed, the doctor runs them in this fixed order:
+
+1. `--restore-cache` runs **first**, before any other step, so subsequent
+   logic (and any helper scripts the doctor itself loads) sees a healthy
+   cache.
+2. The normal pipeline then continues, and `--reinstall` re-downloads the
+   helper binary on top of the now-restored cache.
+
+Running `--reinstall` alone never touches the cache; running
+`--restore-cache` alone never touches the helper binary.
+
 ## Output
 
 ```

--- a/commands/sleepwell-team-fix.md
+++ b/commands/sleepwell-team-fix.md
@@ -1,0 +1,68 @@
+---
+description: Multi-agent coordinated workflow — implement, open PR, dispatch reviewer + fixer agents, wait CI, merge, optional post-merge actions.
+argument-hint: "<intent> [--mode <m>] [--max-iter <N>] [--no-review] [--no-fix] [--max-review-rounds <N>] [--ci-timeout <minutes>] [--no-merge] [--post-merge <action>] [--config <path>]"
+---
+
+# /sleepwell:sleepwell-team-fix
+
+Coordinates a **team of agents** end-to-end: an Implementer runs the standard
+sleepwell loop, a Reviewer inspects the resulting PR with line-level comments,
+a Fixer applies the requested changes, a CI-Watcher waits for green, and an
+optional Post-Merge step ships the change forward (release, downstream
+dispatch, custom command, or no-op).
+
+> **Canonical flow:** see `lib/team-workflow.md`. This file only covers CLI
+> args and dispatching to the `sleepwell-team` skill — no duplicated logic.
+
+## Parsed arguments
+
+```
+<intent>                              first quoted string — required
+--mode tidy|refine|build|radical      forwarded to sleepwell-loop (default: refine)
+--max-iter <N>                        forwarded to sleepwell-loop (default: 20)
+--no-review                           skip the reviewer phase entirely
+--no-fix                              run reviewer but skip fixer (only annotate the PR)
+--max-review-rounds <N>               max reviewer→fixer rounds (default: 2)
+--ci-timeout <minutes>                max minutes waiting for CI (default: 30)
+--no-merge                            stop after CI is green; do not merge
+--post-merge none|release|<custom>    post-merge action (default: from config)
+--config <path>                       alternative path for team.config.yaml
+```
+
+All flags override values from `.sleepwell/team.config.yaml` (or the file
+provided via `--config`). When neither flag nor config define a value, the
+defaults shipped in `team.config.example.yaml` apply.
+
+## Behavior
+
+1. Validate args; load `.sleepwell/team.config.yaml` (or `--config`).
+2. Persist the resolved configuration into `.sleepwell/team-state.json`
+   (`run_id`, `intent`, `mode`, `max_review_rounds`, `ci_timeout_minutes`,
+   `post_merge_action`, `current_round = 0`, `phase = "implement"`).
+3. Invoke the `sleepwell-team` skill with the parsed arguments. The skill
+   coordinates each phase, calling other sleepwell skills/commands as
+   building blocks (`sleepwell-loop`, `sleepwell-pr`) and using
+   `gh` for review threads, replies and CI polling.
+
+## Validations before dispatch
+
+- Repo is git? (else error: "sleepwell-team-fix requires git.")
+- `gh` CLI authenticated? (else error: "Run `gh auth login`.")
+- `.sleepwell/state.json` does not point to a different running loop —
+  if it does, refuse and suggest `/sleepwell:sleepwell-status`.
+
+## Invocation
+
+Now invoke the `sleepwell-team` skill with the input `${ARGUMENTS}`.
+
+The skill takes care of:
+
+- Argument and config parsing
+- Implementer phase (delegates to `sleepwell-loop`)
+- PR creation (delegates to `/sleepwell:sleepwell-pr`)
+- Reviewer + Fixer rounds (line-level comments via `gh api`)
+- CI-Watcher poll (`gh pr checks --watch`)
+- Merge + optional post-merge dispatch
+- Persistence of `.sleepwell/team-state.json`
+
+Do not perform work outside it — only dispatching here.

--- a/commands/sleepwell.md
+++ b/commands/sleepwell.md
@@ -1,6 +1,6 @@
 ---
 description: Starts (or resumes) the autonomous sleepwell loop. Combines gnhf discipline (isolated branch, atomic commit, rollback on fail) with overnight adaptation (voice matching, modes, meta-learning). Runs inside the CC session with a warm cache between iterations.
-argument-hint: "<intent>" [--mode tidy|refine|build|radical] [--max-iter N] [--max-cost USD] [--max-cost-per-iter USD] [--stop-when "<condition>"] [--dry-run] [--no-worktree] [--no-voice] [--no-meta] [--intent-file <path>] [--no-pr] [--draft-pr]
+argument-hint: "<intent>" [--mode tidy|refine|build|radical] [--max-iter N] [--max-cost USD] [--max-cost-per-iter USD] [--stop-when "<condition>"] [--dry-run] [--no-worktree] [--no-voice] [--no-meta] [--intent-file <path>] [--no-pr] [--draft-pr] [--with-team]
 ---
 
 # /sleepwell:sleepwell
@@ -25,11 +25,21 @@ Starts or resumes the autonomous loop. Use the `sleepwell-loop` skill as the ent
 --no-meta                             optional
 --no-pr                               optional (default: creates PR at end of run)
 --draft-pr                            optional (creates PR as draft)
+--with-team                           optional — at end of run delegates to
+                                      /sleepwell:sleepwell-team-fix instead of
+                                      /sleepwell:sleepwell-pr (full team workflow:
+                                      review → fix → CI → merge → post-merge).
+                                      Mutually exclusive with --no-pr.
 ```
 
 > **PR-only flow:** at the end of a run with `status == done`, the loop invokes
 > `/sleepwell:sleepwell-pr` automatically (unless `--no-pr` was passed).
 > Auto-merge is disabled by default. See `commands/sleepwell:sleepwell-pr.md`.
+>
+> **Team workflow:** with `--with-team` the loop instead delegates to
+> `/sleepwell:sleepwell-team-fix` once `status == done`, which runs the full
+> review → fix → CI → merge → optional post-merge pipeline. See
+> `lib/team-workflow.md` and `skills/sleepwell-team/SKILL.md`.
 
 All flags are **persisted in `state.json`** at bootstrap (`worktree_enabled`,
 `no_voice`, `no_meta`, `intent_file`, `cost_budget_usd`,

--- a/lib/team-workflow.md
+++ b/lib/team-workflow.md
@@ -1,0 +1,305 @@
+# sleepwell-team — multi-agent workflow
+
+> **Authoritative source.** Canonical reference for the team workflow.
+> The `sleepwell-team` skill and `/sleepwell:sleepwell-team-fix` command
+> reference this document instead of duplicating logic. Behavior changes
+> begin here.
+
+## §1. Philosophy
+
+The standard sleepwell loop excels at **driving an isolated branch to a
+green commit**. Shipping that change still requires a series of human
+ceremonies: opening the PR, reading the diff, asking for fixes, watching
+CI, merging, optionally cutting a release. The team workflow encodes
+those ceremonies as a deterministic chain of agents, so a single intent
+can flow from idea to merged commit without the operator manually
+context-switching between roles.
+
+Three properties guide the design:
+
+1. **Composition over reimplementation.** Each phase delegates to an
+   existing primitive (`sleepwell-loop`, `/sleepwell:sleepwell-pr`,
+   `gh`). The team skill is a coordinator, not a new engine.
+2. **Configurable, not opinionated.** Defaults ship in
+   `team.config.example.yaml`, but every step is opt-out. Teams
+   without a release flow simply leave `post_merge: [{type: none}]`.
+3. **Auditable.** State is persisted in `.sleepwell/team-state.json`
+   between phases, every reviewer/fixer interaction lives on the PR as
+   a real comment thread, and CI gating uses GitHub's required checks
+   API — there is no parallel ledger to reconcile.
+
+## §2. Personas
+
+### Implementer
+
+Runs `sleepwell-loop` with the user-provided intent, mode and
+`max_iter`. Operates exactly as the standalone loop: isolated branch,
+atomic commit per iter, rollback on failure. Hands control back when
+the loop's status becomes `done` (or aborts upstream).
+
+### Reviewer
+
+A subagent dispatched after the PR exists. Receives the full PR diff
+(scoped per `review.scope`) and a severity rubric, and emits a single
+GitHub review per round. Does **not** modify code. Outputs:
+
+- `APPROVE` when no comments at/above `review.block_on_severity`.
+- `REQUEST_CHANGES` with line-level comments otherwise.
+
+### Fixer
+
+A subagent activated only when there are unresolved review comments
+and `fix.enabled = true`. Reads the comment list, applies code edits
+to the PR branch, creates one commit per round
+(`fix(review): address round N comments`), pushes, and optionally
+replies on each thread with the resolving SHA.
+
+### CI-Watcher
+
+A non-LLM agent: it polls `gh pr checks` (or watches branch protection
+required checks) until success, failure, or timeout. Fail-fast aborts
+on first required-check failure when `ci.fail_fast = true`.
+
+### Post-Merge (optional)
+
+Runs configured actions in order after merge succeeds. Built-in action
+types: `dispatch_workflow`, `run_command`, `shell`, `none`. Errors are
+recorded but do not roll back the merge.
+
+## §3. Macro flow
+
+```
+                    ┌──────────────┐
+                    │  Implementer │ (sleepwell-loop)
+                    └──────┬───────┘
+                           │ status=done
+                           ▼
+                    ┌──────────────┐
+                    │   PR creator │ (/sleepwell:sleepwell-pr)
+                    └──────┬───────┘
+                           ▼
+       ┌───────────────────────────────────────┐
+       │     Reviewer ──comments──► Fixer      │ rounds 1..N
+       │       ▲                       │       │
+       │       └──── re-review ◄───────┘       │
+       └───────────────────────────────────────┘
+                           │ approved or rounds-exhausted
+                           ▼
+                    ┌──────────────┐
+                    │  CI-Watcher  │ (gh pr checks --watch)
+                    └──────┬───────┘
+                           │ green
+                           ▼
+                    ┌──────────────┐
+                    │     Merge    │ (gh pr merge)
+                    └──────┬───────┘
+                           ▼
+                    ┌──────────────┐
+                    │  Post-Merge  │ (workflow / command / shell / none)
+                    └──────────────┘
+```
+
+## §4. Reviewer protocol
+
+### Severity rubric
+
+| Severity | Examples |
+|---|---|
+| `high` | correctness, security, data loss, missing tests for new behavior |
+| `medium` | maintainability, performance regressions, unclear naming |
+| `low` | style nits, redundant comments, minor doc gaps |
+
+`review.block_on_severity` selects the threshold that triggers
+`REQUEST_CHANGES`. Comments below the threshold are still posted but do
+not block.
+
+### REST payload
+
+A single POST per round at `repos/$OWNER/$REPO/pulls/$PR/reviews`:
+
+```json
+{
+  "event": "REQUEST_CHANGES",
+  "body": "Automated review (round 1)",
+  "comments": [
+    {
+      "path": "src/auth/oauth.ts",
+      "line": 42,
+      "side": "RIGHT",
+      "body": "**[high]** Missing PKCE verifier validation before token exchange."
+    },
+    {
+      "path": "src/auth/oauth.ts",
+      "start_line": 70,
+      "start_side": "RIGHT",
+      "line": 88,
+      "side": "RIGHT",
+      "body": "**[medium]** Extract redirect URL builder for testability."
+    }
+  ]
+}
+```
+
+`start_line` is used for multi-line comments; `position` is avoided in
+favor of `line` because it is stable across diff updates.
+
+### Scope
+
+| `scope` value | Behavior |
+|---|---|
+| `changed-files` (default) | Only the files in the PR diff |
+| `full-pr` | All commits in the PR, including unmodified context for surrounding files |
+| `branch-vs-base` | `git diff $base...$head` independent of GitHub's diff view |
+
+## §5. Fixer protocol
+
+1. Fetch unresolved comments:
+   ```bash
+   gh api "repos/$OWNER/$REPO/pulls/$PR/comments" \
+     --jq '.[] | select(.in_reply_to_id == null)'
+   ```
+2. For each comment, decide an action: `apply`, `defer-with-reply`,
+   or `reject-with-reply`. Only `high`-severity comments are eligible
+   for `defer`/`reject` when `block_on_severity = high`.
+3. Group `apply` actions, edit the worktree, run local verify
+   (lint + types + tests). If verify fails, drop changes and reply
+   `defer-with-reply: verify failed locally`.
+4. Commit:
+   ```
+   fix(review): address round N comments
+   ```
+5. Push to PR branch.
+6. Reply on each thread (when `reply_to_threads = true`):
+   ```bash
+   gh api -X POST \
+     "repos/$OWNER/$REPO/pulls/$PR/comments/$COMMENT_ID/replies" \
+     -f body="Addressed in $(git rev-parse --short HEAD)."
+   ```
+
+A round is considered **answered** when every blocking comment has
+either an `apply` commit or an explicit reply. Threads can also be
+resolved via the GraphQL `resolveReviewThread` mutation when the
+GitHub repo enforces resolution gating.
+
+## §6. CI gate
+
+### Polling
+
+Default — `gh pr checks $PR --watch --required --interval $poll`.
+Manual fallback (when `--watch` unsupported):
+
+```bash
+end=$(( $(date +%s) + 60 * MAX_WAIT ))
+while [ "$(date +%s)" -lt "$end" ]; do
+  rollup=$(gh pr view "$PR" --json statusCheckRollup \
+    -q '[.statusCheckRollup[] | {name, conclusion, status}]')
+  # … evaluate …
+  sleep "$poll_interval_secs"
+done
+```
+
+### Required checks
+
+When `required_checks` is empty, the workflow consults branch
+protection (`gh api repos/$OWNER/$REPO/branches/$BASE/protection`) and
+requires the same set. Setting `required_checks` explicitly overrides
+that — useful when working against a base branch without protection.
+
+### Retry policy
+
+There is no automatic retry of CI runs from the team workflow. If a
+required check fails, the run finalizes `ci_failed` and leaves the PR
+open with a comment explaining the failure. The user (or another
+sleepwell run) decides whether to push a fix.
+
+## §7. Merge protocol
+
+| `merge.strategy` | `gh pr merge` flag |
+|---|---|
+| `squash` (default) | `--squash` |
+| `merge` | `--merge` |
+| `rebase` | `--rebase` |
+
+`merge.delete_branch = true` adds `--delete-branch`. When
+`merge.auto_merge = true`, the skill calls `gh pr merge --auto $flag`
+instead of waiting locally — it relinquishes control to GitHub once
+the PR satisfies branch protection. In that case the team-state
+phase moves to `awaiting_auto_merge` and the run completes without
+post-merge hooks (because the merge happens server-side, possibly
+much later).
+
+Conflicts during merge raise `merge_conflict`. The skill never resolves
+conflicts unattended.
+
+## §8. Post-merge hooks
+
+Configured as an ordered list under `post_merge:`. Each entry is an
+object with at least `type`. Built-in types:
+
+- **`dispatch_workflow`** — `gh workflow run <workflow> -f k=v …`.
+  Useful for triggering bump/release pipelines after merge.
+- **`run_command`** — invokes a sleepwell command in the same session
+  (`/sleepwell:sleepwell-recap`, `/sleepwell:sleepwell-suggest`, etc.).
+- **`shell`** — runs a literal shell command. Must match the
+  allowlist in `post_merge.allowed_shell` (regex). Disabled by default.
+- **`none`** — explicit no-op (recommended default for teams without
+  release automation).
+
+Errors are accumulated into `team-state.post_merge_errors[]` and the
+final status becomes `merged_with_post_merge_errors` instead of
+`done` — but the merge itself is **not** rolled back.
+
+## §9. State persistence
+
+`.sleepwell/team-state.json` is the single source of truth between
+phases:
+
+```json
+{
+  "run_id": "team-2026-05-03-abcd",
+  "intent": "implement OAuth2 with PKCE",
+  "mode": "build",
+  "branch": "sleepwell/oauth2-pkce",
+  "pr_number": 142,
+  "pr_url": "https://github.com/owner/repo/pull/142",
+  "phase": "review",
+  "current_round": 1,
+  "max_review_rounds": 2,
+  "ci_timeout_minutes": 30,
+  "post_merge_action": "none",
+  "review_comments_seen": [123, 124, 125],
+  "ci_status": "pending",
+  "merged_sha": null,
+  "post_merge_errors": [],
+  "started_at": "2026-05-03T22:00:00Z",
+  "updated_at": "2026-05-03T22:14:00Z"
+}
+```
+
+Writes are atomic (`mktemp` + `mv`). The file is added to
+`.gitignore` along with the rest of `.sleepwell/`.
+
+The team-state references the loop's `state.json` via `branch`. The two
+files coexist: the loop owns iteration data; the team owns the
+post-loop pipeline.
+
+## §10. Configuration via YAML
+
+Defaults ship in `.sleepwell/team.config.example.yaml` (copy into
+`.sleepwell/team.config.yaml` and edit). Resolution order:
+
+1. CLI flags on `/sleepwell:sleepwell-team-fix`.
+2. `--config <path>` if provided.
+3. `.sleepwell/team.config.yaml` in the repo.
+4. Defaults from `team.config.example.yaml`.
+
+YAML values can be partially overridden — missing keys fall back to
+the next layer. Validation:
+
+- `review.max_rounds` must be `>= 1`.
+- `ci.max_wait_minutes` must be `>= 1`.
+- `merge.strategy` must be one of `squash | merge | rebase`.
+- `post_merge[].type` must be one of the documented types.
+
+The team skill validates the merged config at startup and aborts with
+a descriptive error before any agent is dispatched.

--- a/lib/team-workflow.md
+++ b/lib/team-workflow.md
@@ -110,8 +110,17 @@ recorded but do not roll back the merge.
 | `low` | style nits, redundant comments, minor doc gaps |
 
 `review.block_on_severity` selects the threshold that triggers
-`REQUEST_CHANGES`. Comments below the threshold are still posted but do
-not block.
+`REQUEST_CHANGES`. Accepted values, in order of permissiveness:
+
+| Value | Blocks on |
+|---|---|
+| `any` | any comment (alias of `low`) |
+| `low` | low, medium, high |
+| `medium` | medium, high |
+| `high` | high only (default) |
+| `none` | never blocks — review is advisory |
+
+Comments below the threshold are still posted but do not block.
 
 ### REST payload
 

--- a/scripts/restore-plugin-cache.sh
+++ b/scripts/restore-plugin-cache.sh
@@ -1,0 +1,195 @@
+#!/usr/bin/env bash
+# restore-plugin-cache.sh — standalone recovery for sleepwell plugin cache.
+#
+# Reads ~/.claude/plugins/installed_plugins.json, finds sleepwell entries,
+# detects broken cache directories (missing or empty .claude-plugin/plugin.json
+# or commands/), and restores them via `git clone` from the upstream repo.
+#
+# Usage:
+#   bash scripts/restore-plugin-cache.sh                # auto-detect and fix
+#   bash scripts/restore-plugin-cache.sh --dry-run      # report only
+#   bash scripts/restore-plugin-cache.sh --force        # re-clone even if ok
+#   bash scripts/restore-plugin-cache.sh --verbose      # extra logging
+#
+# Designed to run **without** the plugin being loaded. Standalone — usable via:
+#   bash <(curl -fsSL https://raw.githubusercontent.com/FelipeOFF/sleepwell/main/scripts/restore-plugin-cache.sh)
+#
+# Requires: bash, git, python3 (universal on macOS/Linux dev boxes).
+set -euo pipefail
+
+REPO_URL="https://github.com/FelipeOFF/sleepwell.git"
+PLUGINS_JSON="${HOME}/.claude/plugins/installed_plugins.json"
+DRY_RUN=0
+FORCE=0
+VERBOSE=0
+
+log()  { echo "[sleepwell-restore] $*" >&2; }
+vlog() { [ "$VERBOSE" = "1" ] && echo "[sleepwell-restore] (debug) $*" >&2 || true; }
+err()  { echo "[sleepwell-restore] error: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --dry-run) DRY_RUN=1; shift ;;
+    --force)   FORCE=1;   shift ;;
+    --verbose) VERBOSE=1; shift ;;
+    -h|--help)
+      sed -n '2,18p' "$0"
+      exit 0
+      ;;
+    *) err "unknown arg: $1" ;;
+  esac
+done
+
+command -v git     >/dev/null 2>&1 || err "git not found in PATH"
+command -v python3 >/dev/null 2>&1 || err "python3 not found in PATH"
+
+[ -f "$PLUGINS_JSON" ] || err "installed_plugins.json not found at $PLUGINS_JSON"
+
+# Extract sleepwell entries: lines of "<key>\t<installPath>\t<sha>\t<version>".
+ENTRIES="$(python3 - "$PLUGINS_JSON" <<'PY'
+import json, sys
+path = sys.argv[1]
+with open(path) as f:
+    data = json.load(f)
+for key, arr in (data.get("plugins") or {}).items():
+    if not key.startswith("sleepwell@"):
+        continue
+    for entry in arr:
+        ip = entry.get("installPath", "")
+        sha = entry.get("gitCommitSha", "") or ""
+        ver = entry.get("version", "") or ""
+        print(f"{key}\t{ip}\t{sha}\t{ver}")
+PY
+)"
+
+if [ -z "$ENTRIES" ]; then
+  log "no sleepwell@* entries found in installed_plugins.json — nothing to do."
+  exit 0
+fi
+
+is_broken() {
+  local p="$1"
+  [ -d "$p" ] || return 0
+  [ -f "$p/.claude-plugin/plugin.json" ] || return 0
+  # commands/ must exist and contain at least one .md
+  [ -d "$p/commands" ] || return 0
+  local n
+  n="$(find "$p/commands" -maxdepth 1 -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' ')"
+  [ "${n:-0}" -gt 0 ] || return 0
+  return 1
+}
+
+count_commands() {
+  local p="$1"
+  if [ -d "$p/commands" ]; then
+    find "$p/commands" -maxdepth 1 -name '*.md' -type f 2>/dev/null | wc -l | tr -d ' '
+  else
+    echo 0
+  fi
+}
+
+restore_entry() {
+  local install_path="$1" sha="$2" version="$3"
+  local parent
+  parent="$(dirname "$install_path")"
+
+  if [ "$DRY_RUN" = "1" ]; then
+    log "[dry-run] would clone $REPO_URL → $install_path (sha=${sha:-main})"
+    return 0
+  fi
+
+  mkdir -p "$parent"
+
+  # Backup existing dir if any
+  if [ -e "$install_path" ]; then
+    local backup="${install_path}.broken.$(date +%s)"
+    vlog "moving existing $install_path → $backup"
+    mv "$install_path" "$backup"
+  fi
+
+  log "cloning $REPO_URL → $install_path"
+  git clone --quiet "$REPO_URL" "$install_path" || err "git clone failed"
+
+  local new_sha=""
+  if [ -n "$sha" ]; then
+    if git -C "$install_path" cat-file -e "$sha^{commit}" 2>/dev/null; then
+      vlog "checking out recorded sha $sha"
+      git -C "$install_path" checkout --quiet "$sha"
+      new_sha="$sha"
+    else
+      log "recorded sha $sha not reachable; falling back to main"
+      git -C "$install_path" checkout --quiet main
+      new_sha="$(git -C "$install_path" rev-parse HEAD 2>/dev/null)"
+    fi
+  else
+    git -C "$install_path" checkout --quiet main
+    new_sha="$(git -C "$install_path" rev-parse HEAD 2>/dev/null)"
+  fi
+
+  printf '%s\n' "$new_sha"
+}
+
+update_json() {
+  local key="$1" install_path="$2" new_sha="$3"
+  python3 - "$PLUGINS_JSON" "$key" "$install_path" "$new_sha" <<'PY'
+import json, sys, datetime
+path, key, install_path, new_sha = sys.argv[1:5]
+with open(path) as f:
+    data = json.load(f)
+arr = (data.get("plugins") or {}).get(key, [])
+now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.") + \
+      f"{datetime.datetime.utcnow().microsecond // 1000:03d}Z"
+for entry in arr:
+    if entry.get("installPath") == install_path:
+        entry["gitCommitSha"] = new_sha
+        entry["lastUpdated"] = now
+with open(path, "w") as f:
+    json.dump(data, f, indent=2)
+    f.write("\n")
+PY
+}
+
+ANY_BROKEN=0
+ANY_RESTORED=0
+
+# IFS-safe iteration over tab-separated lines.
+while IFS=$'\t' read -r KEY IPATH SHA VER; do
+  [ -n "$KEY" ] || continue
+  log "checking $KEY @ $IPATH (version=$VER)"
+  if is_broken "$IPATH"; then
+    ANY_BROKEN=1
+    log "  → broken cache detected"
+  elif [ "$FORCE" = "1" ]; then
+    log "  → cache valid (--force, re-cloning anyway)"
+  else
+    LOCAL_COUNT="$(count_commands "$IPATH")"
+    log "  ✓ cache valid ($LOCAL_COUNT commands), no action needed"
+    continue
+  fi
+
+  if [ "$DRY_RUN" = "1" ]; then
+    restore_entry "$IPATH" "$SHA" "$VER" >/dev/null
+    continue
+  fi
+
+  NEW_SHA="$(restore_entry "$IPATH" "$SHA" "$VER" | tail -n1)"
+  update_json "$KEY" "$IPATH" "$NEW_SHA"
+
+  if is_broken "$IPATH"; then
+    err "post-restore integrity check FAILED for $IPATH"
+  fi
+  LOCAL_COUNT="$(count_commands "$IPATH")"
+  log "  ✓ restored ($LOCAL_COUNT commands) at sha=$NEW_SHA"
+  ANY_RESTORED=1
+done <<< "$ENTRIES"
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "dry-run complete."
+  exit 0
+fi
+
+if [ "$ANY_RESTORED" = "1" ]; then
+  log "done. Run /reload-plugins in Claude Code to apply."
+elif [ "$ANY_BROKEN" = "0" ]; then
+  log "all sleepwell caches healthy — nothing to do."
+fi

--- a/scripts/restore-plugin-cache.sh
+++ b/scripts/restore-plugin-cache.sh
@@ -11,17 +11,30 @@
 #   bash scripts/restore-plugin-cache.sh --force        # re-clone even if ok
 #   bash scripts/restore-plugin-cache.sh --verbose      # extra logging
 #
+# Repo selection (for forks/mirrors):
+#   1. SLEEPWELL_REPO env var (e.g. "myorg/sleepwell" or full https URL).
+#   2. Inferred from `installed_plugins.json` entries `sleepwell@<owner>/<repo>`
+#      when they encode the source repo.
+#   3. Fallback: FelipeOFF/sleepwell.
+#
+# Backup retention:
+#   Old `.broken.<ts>` directories left from previous restores are pruned
+#   automatically after a successful run. Default TTL: 7 days. Override with
+#   SLEEPWELL_BROKEN_TTL_DAYS=<n> (set to 0 to disable cleanup).
+#
 # Designed to run **without** the plugin being loaded. Standalone — usable via:
 #   bash <(curl -fsSL https://raw.githubusercontent.com/FelipeOFF/sleepwell/main/scripts/restore-plugin-cache.sh)
 #
 # Requires: bash, git, python3 (universal on macOS/Linux dev boxes).
 set -euo pipefail
 
-REPO_URL="https://github.com/FelipeOFF/sleepwell.git"
 PLUGINS_JSON="${HOME}/.claude/plugins/installed_plugins.json"
 DRY_RUN=0
 FORCE=0
 VERBOSE=0
+SLEEPWELL_REPO="${SLEEPWELL_REPO:-}"
+SLEEPWELL_BROKEN_TTL_DAYS="${SLEEPWELL_BROKEN_TTL_DAYS:-7}"
+DEFAULT_REPO="FelipeOFF/sleepwell"
 
 log()  { echo "[sleepwell-restore] $*" >&2; }
 vlog() { [ "$VERBOSE" = "1" ] && echo "[sleepwell-restore] (debug) $*" >&2 || true; }
@@ -32,8 +45,9 @@ while [ $# -gt 0 ]; do
     --dry-run) DRY_RUN=1; shift ;;
     --force)   FORCE=1;   shift ;;
     --verbose) VERBOSE=1; shift ;;
+    --repo)    SLEEPWELL_REPO="$2"; shift 2 ;;
     -h|--help)
-      sed -n '2,18p' "$0"
+      sed -n '2,28p' "$0"
       exit 0
       ;;
     *) err "unknown arg: $1" ;;
@@ -44,6 +58,47 @@ command -v git     >/dev/null 2>&1 || err "git not found in PATH"
 command -v python3 >/dev/null 2>&1 || err "python3 not found in PATH"
 
 [ -f "$PLUGINS_JSON" ] || err "installed_plugins.json not found at $PLUGINS_JSON"
+
+# Resolve REPO_URL from (1) override, (2) inference from installed_plugins.json
+# entries shaped `sleepwell@<owner>/<repo>`, (3) DEFAULT_REPO fallback.
+resolve_repo_url() {
+  if [ -n "$SLEEPWELL_REPO" ]; then
+    case "$SLEEPWELL_REPO" in
+      http*|git@*) echo "$SLEEPWELL_REPO" ;;
+      *)           echo "https://github.com/${SLEEPWELL_REPO}.git" ;;
+    esac
+    return 0
+  fi
+  local inferred
+  inferred="$(python3 - "$PLUGINS_JSON" <<'PY'
+import json, sys, re
+try:
+    with open(sys.argv[1]) as f:
+        data = json.load(f)
+except Exception:
+    sys.exit(0)
+for key in (data.get("plugins") or {}).keys():
+    # accept patterns like "sleepwell@owner/repo" or "sleepwell@owner"
+    m = re.match(r"^sleepwell@([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?)$", key)
+    if not m:
+        continue
+    val = m.group(1)
+    if "/" not in val:
+        # owner only — pair with repo name "sleepwell"
+        val = f"{val}/sleepwell"
+    print(val)
+    break
+PY
+)"
+  if [ -n "$inferred" ]; then
+    echo "https://github.com/${inferred}.git"
+  else
+    echo "https://github.com/${DEFAULT_REPO}.git"
+  fi
+}
+
+REPO_URL="$(resolve_repo_url)"
+log "using repo: $REPO_URL"
 
 # Extract sleepwell entries: lines of "<key>\t<installPath>\t<sha>\t<version>".
 ENTRIES="$(python3 - "$PLUGINS_JSON" <<'PY'
@@ -88,27 +143,68 @@ count_commands() {
   fi
 }
 
+# Detect default branch of REPO_URL (some forks use "master" instead of "main").
+detect_default_branch() {
+  local repo_path="$1"
+  local b
+  b="$(git -C "$repo_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null \
+       | sed 's|^origin/||' || true)"
+  if [ -z "$b" ]; then
+    # remotes/origin/HEAD missing — try to set it, then reread.
+    git -C "$repo_path" remote set-head origin --auto >/dev/null 2>&1 || true
+    b="$(git -C "$repo_path" symbolic-ref --quiet --short refs/remotes/origin/HEAD 2>/dev/null \
+         | sed 's|^origin/||' || true)"
+  fi
+  [ -n "$b" ] || b="main"
+  echo "$b"
+}
+
+# Prune `.broken.<ts>` siblings older than SLEEPWELL_BROKEN_TTL_DAYS.
+prune_old_backups() {
+  local install_path="$1"
+  [ "${SLEEPWELL_BROKEN_TTL_DAYS:-0}" -gt 0 ] || return 0
+  local parent base
+  parent="$(dirname "$install_path")"
+  base="$(basename "$install_path")"
+  [ -d "$parent" ] || return 0
+  find "$parent" -maxdepth 1 -type d -name "${base}.broken.*" \
+    -mtime "+${SLEEPWELL_BROKEN_TTL_DAYS}" 2>/dev/null | while read -r old; do
+      vlog "pruning old backup: $old"
+      rm -rf "$old"
+    done
+}
+
 restore_entry() {
   local install_path="$1" sha="$2" version="$3"
   local parent
   parent="$(dirname "$install_path")"
 
   if [ "$DRY_RUN" = "1" ]; then
-    log "[dry-run] would clone $REPO_URL → $install_path (sha=${sha:-main})"
+    log "[dry-run] would clone $REPO_URL → $install_path (sha=${sha:-<default-branch>})"
     return 0
   fi
 
   mkdir -p "$parent"
 
-  # Backup existing dir if any
+  # Backup existing dir if any (kept for SLEEPWELL_BROKEN_TTL_DAYS, then pruned).
   if [ -e "$install_path" ]; then
     local backup="${install_path}.broken.$(date +%s)"
     vlog "moving existing $install_path → $backup"
     mv "$install_path" "$backup"
   fi
 
+  # Clone into a `.partial` and rename on success so an interrupted clone never
+  # leaves a half-baked dir at the canonical path.
+  local partial="${install_path}.partial.$$"
+  trap 'rm -rf "$partial"' EXIT INT TERM
+
   log "cloning $REPO_URL → $install_path"
-  git clone --quiet "$REPO_URL" "$install_path" || err "git clone failed"
+  git clone --quiet "$REPO_URL" "$partial" || err "git clone failed"
+  mv "$partial" "$install_path"
+  trap - EXIT INT TERM
+
+  local default_branch
+  default_branch="$(detect_default_branch "$install_path")"
 
   local new_sha=""
   if [ -n "$sha" ]; then
@@ -117,35 +213,40 @@ restore_entry() {
       git -C "$install_path" checkout --quiet "$sha"
       new_sha="$sha"
     else
-      log "recorded sha $sha not reachable; falling back to main"
-      git -C "$install_path" checkout --quiet main
+      log "recorded sha $sha not reachable; falling back to $default_branch"
+      git -C "$install_path" checkout --quiet "$default_branch"
       new_sha="$(git -C "$install_path" rev-parse HEAD 2>/dev/null)"
     fi
   else
-    git -C "$install_path" checkout --quiet main
+    git -C "$install_path" checkout --quiet "$default_branch"
     new_sha="$(git -C "$install_path" rev-parse HEAD 2>/dev/null)"
   fi
 
-  printf '%s\n' "$new_sha"
+  # Persist the resolved sha to a sibling tmp file (avoids stdout coupling).
+  printf '%s\n' "$new_sha" > "${install_path}.last_sha"
 }
 
 update_json() {
   local key="$1" install_path="$2" new_sha="$3"
   python3 - "$PLUGINS_JSON" "$key" "$install_path" "$new_sha" <<'PY'
-import json, sys, datetime
+import json, os, sys, datetime
 path, key, install_path, new_sha = sys.argv[1:5]
 with open(path) as f:
     data = json.load(f)
 arr = (data.get("plugins") or {}).get(key, [])
-now = datetime.datetime.utcnow().strftime("%Y-%m-%dT%H:%M:%S.") + \
-      f"{datetime.datetime.utcnow().microsecond // 1000:03d}Z"
+# Single timestamp source — datetime.now(UTC) replaces deprecated utcnow.
+now_dt = datetime.datetime.now(datetime.timezone.utc)
+now = now_dt.strftime("%Y-%m-%dT%H:%M:%S.") + f"{now_dt.microsecond // 1000:03d}Z"
 for entry in arr:
     if entry.get("installPath") == install_path:
         entry["gitCommitSha"] = new_sha
         entry["lastUpdated"] = now
-with open(path, "w") as f:
+# Atomic write: tmp file + os.replace prevents corruption on crash/SIGINT.
+tmp = path + ".tmp." + str(os.getpid())
+with open(tmp, "w") as f:
     json.dump(data, f, indent=2)
     f.write("\n")
+os.replace(tmp, path)
 PY
 }
 
@@ -168,11 +269,16 @@ while IFS=$'\t' read -r KEY IPATH SHA VER; do
   fi
 
   if [ "$DRY_RUN" = "1" ]; then
-    restore_entry "$IPATH" "$SHA" "$VER" >/dev/null
+    restore_entry "$IPATH" "$SHA" "$VER"
     continue
   fi
 
-  NEW_SHA="$(restore_entry "$IPATH" "$SHA" "$VER" | tail -n1)"
+  restore_entry "$IPATH" "$SHA" "$VER"
+  NEW_SHA=""
+  if [ -f "${IPATH}.last_sha" ]; then
+    NEW_SHA="$(cat "${IPATH}.last_sha")"
+    rm -f "${IPATH}.last_sha"
+  fi
   update_json "$KEY" "$IPATH" "$NEW_SHA"
 
   if is_broken "$IPATH"; then
@@ -181,6 +287,9 @@ while IFS=$'\t' read -r KEY IPATH SHA VER; do
   LOCAL_COUNT="$(count_commands "$IPATH")"
   log "  ✓ restored ($LOCAL_COUNT commands) at sha=$NEW_SHA"
   ANY_RESTORED=1
+
+  # Restore succeeded — prune old `.broken.*` siblings beyond TTL.
+  prune_old_backups "$IPATH"
 done <<< "$ENTRIES"
 
 if [ "$DRY_RUN" = "1" ]; then

--- a/scripts/restore-plugin-cache.sh
+++ b/scripts/restore-plugin-cache.sh
@@ -175,7 +175,8 @@ prune_old_backups() {
 }
 
 restore_entry() {
-  local install_path="$1" sha="$2" version="$3"
+  local install_path="$1" sha="$2"
+  # $3 is the version field (reserved for per-version logic; currently unused)
   local parent
   parent="$(dirname "$install_path")"
 
@@ -188,7 +189,8 @@ restore_entry() {
 
   # Backup existing dir if any (kept for SLEEPWELL_BROKEN_TTL_DAYS, then pruned).
   if [ -e "$install_path" ]; then
-    local backup="${install_path}.broken.$(date +%s)"
+    local backup
+    backup="${install_path}.broken.$(date +%s)"
     vlog "moving existing $install_path → $backup"
     mv "$install_path" "$backup"
   fi

--- a/skills/sleepwell-team/SKILL.md
+++ b/skills/sleepwell-team/SKILL.md
@@ -20,7 +20,7 @@ Four coordinated agents, plus an optional fifth:
 | Implementer | Drives `sleepwell-loop` until status `done` (or aborted). | `sleepwell-loop` skill |
 | Reviewer | Inspects PR diff and posts line-level review comments. | `gh api` (REST reviews endpoint) |
 | Fixer | Reads review comments, applies changes, replies in-thread. | Edit/Write + `gh api` replies |
-| CI-Watcher | Polls PR checks until green or timeout. | `gh pr checks --watch` |
+| CI-Watcher | Polls PR checks until green or timeout (handles "no checks" edge case). | `gh pr checks --json` |
 | Post-Merge (optional) | Runs configured action after merge succeeds. | Workflow dispatch / shell / sleepwell command |
 
 ## Activation
@@ -130,17 +130,19 @@ The Reviewer is dispatched as a subagent (`config.review.agent`,
 - A review rubric (severity levels: `low`, `medium`, `high`).
 
 It must output a JSON array of comments and submit them as a single review
-via:
+via `gh api ... --input -`. **Important:** when `--input` is present, `-f` /
+`-F` flags are ignored — `event` and `body` MUST live inside the JSON
+payload, not as separate flags.
 
 ```bash
 gh api \
   -X POST \
   -H "Accept: application/vnd.github+json" \
   "repos/$OWNER/$REPO/pulls/$PR/reviews" \
-  -f event="REQUEST_CHANGES" \
-  -f body="Automated review (round $ROUND)" \
   --input - <<'JSON'
 {
+  "event": "REQUEST_CHANGES",
+  "body": "Automated review (round 1)",
   "comments": [
     { "path": "src/auth/oauth.ts", "line": 42, "side": "RIGHT",
       "body": "**[high]** Missing PKCE verifier validation before token exchange." },
@@ -156,8 +158,39 @@ Reviewer submits `event=APPROVE` and the loop exits the round.
 
 ## Fixer protocol
 
-The Fixer receives the list of unresolved review comments (`gh api
-repos/$OWNER/$REPO/pulls/$PR/comments`) and:
+The Fixer receives the list of **unresolved** review comments. The REST
+endpoint `repos/$OWNER/$REPO/pulls/$PR/comments` returns *every* review
+comment on the PR (including resolved threads and prior rounds), so we use
+the GraphQL `reviewThreads { isResolved }` projection instead and filter
+client-side:
+
+```bash
+gh api graphql \
+  -F owner="$OWNER" -F repo="$REPO" -F pr="$PR" \
+  -f query='
+    query($owner:String!, $repo:String!, $pr:Int!) {
+      repository(owner:$owner, name:$repo) {
+        pullRequest(number:$pr) {
+          reviewThreads(first:100) {
+            nodes {
+              id
+              isResolved
+              comments(first:50) {
+                nodes { id databaseId path line body }
+              }
+            }
+          }
+        }
+      }
+    }' \
+  --jq '.data.repository.pullRequest.reviewThreads.nodes
+        | map(select(.isResolved == false))
+        | .[].comments.nodes[]
+        | {id: .databaseId, path, line, body}'
+```
+
+The Fixer also intersects the result with `team-state.review_comments_seen`
+to avoid replying twice to the same comment across rounds. Then:
 
 1. Applies edits to the worktree.
 2. Commits as `fix(review): address round N comments` (one commit per round).
@@ -177,28 +210,55 @@ does not reply (the next reviewer round will re-evaluate).
 
 ## CI-Watcher protocol
 
+`gh pr checks` does **not** accept `--required`. Valid flags are
+`--watch`, `--interval`, `--fail-fast`, `--json`, `--required` is **not**
+one of them. The blocking, simple-mode form is:
+
 ```bash
-gh pr checks "$PR" --watch --interval "$POLL" --required \
+gh pr checks "$PR" --watch --interval "$POLL" \
+  ${CI_FAIL_FAST:+--fail-fast} \
   || ci_failed=1
 ```
 
-Falls back to a manual loop when `--watch` is unavailable:
+This is acceptable as a fallback. The recommended form is a manual poll
+loop driven by `gh pr checks --json`, which lets us implement timeouts,
+the "no checks configured" edge case, and per-check filtering against
+`config.ci.required_checks`:
 
 ```bash
 end=$(( $(date +%s) + 60 * MAX_WAIT ))
+empty_polls=0
 while [ "$(date +%s)" -lt "$end" ]; do
-  status=$(gh pr view "$PR" --json statusCheckRollup -q \
-    '[.statusCheckRollup[].conclusion] | unique | join(",")')
-  case "$status" in
-    *FAILURE*|*CANCELLED*|*TIMED_OUT*) ci_failed=1; break ;;
-    *SUCCESS*) [[ "$status" != *PENDING* ]] && break ;;
+  rollup="$(gh pr checks "$PR" --json name,state,bucket 2>/dev/null || echo '[]')"
+  count="$(echo "$rollup" | jq 'length')"
+
+  # Edge case: workflows may not have started yet, or the PR has no
+  # required CI configured at all. Wait a bit before declaring "no CI".
+  if [ "$count" = "0" ]; then
+    empty_polls=$((empty_polls + 1))
+    if [ "$empty_polls" -ge 3 ]; then
+      log "no checks configured after 3 empty polls — proceeding (allow_no_checks)"
+      break
+    fi
+    sleep 30
+    continue
+  fi
+  empty_polls=0
+
+  # bucket is one of: pass | fail | pending | skipping | cancel
+  buckets="$(echo "$rollup" | jq -r '[.[].bucket] | unique | join(",")')"
+  case "$buckets" in
+    *fail*|*cancel*) ci_failed=1; break ;;
+    *pending*)       sleep "$POLL" ;;
+    *)               break ;;  # all pass / skipping
   esac
-  sleep "$POLL"
 done
 ```
 
-`required_checks` from config can pin specific check names; otherwise the
-detected branch protection rules are used.
+`required_checks` from config can pin specific check names (filter the
+`rollup` jq query by `.name`); otherwise the detected branch protection
+rules are used. Set `CI_FAIL_FAST=1` (mirrors `ci.fail_fast`) when using
+the `--watch` fallback.
 
 ## Merge protocol
 

--- a/skills/sleepwell-team/SKILL.md
+++ b/skills/sleepwell-team/SKILL.md
@@ -1,0 +1,258 @@
+---
+name: sleepwell-team
+description: Orchestrates multi-agent PR workflow — implement → PR → review → fix → CI → merge → optional post-merge. Use when you want a coordinated team-of-agents to ship a change end-to-end.
+---
+
+# sleepwell-team
+
+Coordinates a multi-agent workflow on top of the existing sleepwell primitives.
+Activated by `/sleepwell:sleepwell-team-fix "<intent>" [opts]`.
+
+> **Authoritative flow:** `lib/team-workflow.md`. This skill **implements** the
+> ritual described there — when in doubt, the lib file wins.
+
+## Architecture
+
+Four coordinated agents, plus an optional fifth:
+
+| Agent | Role | Tooling |
+|---|---|---|
+| Implementer | Drives `sleepwell-loop` until status `done` (or aborted). | `sleepwell-loop` skill |
+| Reviewer | Inspects PR diff and posts line-level review comments. | `gh api` (REST reviews endpoint) |
+| Fixer | Reads review comments, applies changes, replies in-thread. | Edit/Write + `gh api` replies |
+| CI-Watcher | Polls PR checks until green or timeout. | `gh pr checks --watch` |
+| Post-Merge (optional) | Runs configured action after merge succeeds. | Workflow dispatch / shell / sleepwell command |
+
+## Activation
+
+- User invokes `/sleepwell:sleepwell-team-fix`.
+- Or another skill explicitly delegates orchestration here.
+
+## Inputs
+
+Forwarded from the command:
+
+```
+<intent>                  required
+--mode <m>                forwarded to sleepwell-loop
+--max-iter <N>            forwarded to sleepwell-loop
+--no-review               skip review phase
+--no-fix                  skip fixer (review-only)
+--max-review-rounds <N>   default 2
+--ci-timeout <minutes>    default 30
+--no-merge                stop after CI green
+--post-merge <action>     overrides config
+--config <path>           alternative team.config.yaml
+```
+
+Plus `.sleepwell/team.config.yaml` (or `--config`). See
+`.sleepwell/team.config.example.yaml`.
+
+## Persisted state — `.sleepwell/team-state.json`
+
+```json
+{
+  "run_id": "team-2026-05-03-abcd",
+  "intent": "implement OAuth2 with PKCE",
+  "mode": "build",
+  "branch": "sleepwell/oauth2-pkce",
+  "pr_number": 142,
+  "pr_url": "https://github.com/owner/repo/pull/142",
+  "phase": "review|fix|ci|merge|post_merge|done|aborted",
+  "current_round": 1,
+  "max_review_rounds": 2,
+  "ci_timeout_minutes": 30,
+  "post_merge_action": "none",
+  "review_comments_seen": [123, 124, 125],
+  "ci_status": "pending|success|failure",
+  "merged_sha": null,
+  "started_at": "2026-05-03T22:00:00Z",
+  "updated_at": "2026-05-03T22:14:00Z"
+}
+```
+
+The file lives next to `state.json` — both can coexist (the loop's state is
+referenced by the team state via `branch`).
+
+## Pseudocode (high level)
+
+```
+parse_args()
+config = load_config(args.config or ".sleepwell/team.config.yaml")
+state  = init_team_state(args, config)
+
+# 1. Implement
+invoke_skill("sleepwell-loop", intent=state.intent, mode=state.mode,
+             max_iter=state.max_iter)
+wait_until(loop_status in {"done", "aborted"})
+if loop_status != "done": finalize("aborted_implement"); return
+
+# 2. PR
+run_command("/sleepwell:sleepwell-pr")
+state.pr_number = extract_pr_number_from(loop_state.pr_url)
+persist(state)
+
+# 3. Review/Fix rounds
+if config.review.enabled and not args.no_review:
+  for round in 1..config.review.max_rounds:
+    state.phase = "review"; state.current_round = round; persist(state)
+    review_comments = run_reviewer(state.pr_number, config.review)
+    if not review_comments: break  # reviewer approved
+    if not config.fix.enabled or args.no_fix: break
+    state.phase = "fix"; persist(state)
+    run_fixer(state.pr_number, review_comments, config.fix)
+
+# 4. CI gate
+if not args.no_merge:
+  state.phase = "ci"; persist(state)
+  ci_ok = poll_ci(state.pr_number, config.ci, args.ci_timeout)
+  if not ci_ok: finalize("ci_failed"); return
+
+  # 5. Merge
+  state.phase = "merge"; persist(state)
+  merge_pr(state.pr_number, config.merge)
+
+  # 6. Post-merge
+  state.phase = "post_merge"; persist(state)
+  for action in resolve_post_merge(config, args):
+    dispatch_post_merge(action)
+
+finalize("done")
+```
+
+## Reviewer protocol
+
+The Reviewer is dispatched as a subagent (`config.review.agent`,
+`general-purpose` by default). It is given:
+
+- The PR number and base/head SHAs.
+- The diff (`gh pr diff $PR`) limited by `config.review.scope`.
+- A review rubric (severity levels: `low`, `medium`, `high`).
+
+It must output a JSON array of comments and submit them as a single review
+via:
+
+```bash
+gh api \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$OWNER/$REPO/pulls/$PR/reviews" \
+  -f event="REQUEST_CHANGES" \
+  -f body="Automated review (round $ROUND)" \
+  --input - <<'JSON'
+{
+  "comments": [
+    { "path": "src/auth/oauth.ts", "line": 42, "side": "RIGHT",
+      "body": "**[high]** Missing PKCE verifier validation before token exchange." },
+    { "path": "src/auth/oauth.ts", "line": 88, "side": "RIGHT",
+      "body": "**[medium]** Consider extracting redirect URL builder for testability." }
+  ]
+}
+JSON
+```
+
+If `block_on_severity` is `none` or no comments meet the threshold, the
+Reviewer submits `event=APPROVE` and the loop exits the round.
+
+## Fixer protocol
+
+The Fixer receives the list of unresolved review comments (`gh api
+repos/$OWNER/$REPO/pulls/$PR/comments`) and:
+
+1. Applies edits to the worktree.
+2. Commits as `fix(review): address round N comments` (one commit per round).
+3. Pushes to the PR branch.
+4. For each addressed comment, posts a reply on the same thread:
+
+```bash
+gh api \
+  -X POST \
+  -H "Accept: application/vnd.github+json" \
+  "repos/$OWNER/$REPO/pulls/$PR/comments/$COMMENT_ID/replies" \
+  -f body="Addressed in $(git rev-parse --short HEAD)."
+```
+
+When `config.fix.reply_to_threads = false`, the Fixer pushes the commit but
+does not reply (the next reviewer round will re-evaluate).
+
+## CI-Watcher protocol
+
+```bash
+gh pr checks "$PR" --watch --interval "$POLL" --required \
+  || ci_failed=1
+```
+
+Falls back to a manual loop when `--watch` is unavailable:
+
+```bash
+end=$(( $(date +%s) + 60 * MAX_WAIT ))
+while [ "$(date +%s)" -lt "$end" ]; do
+  status=$(gh pr view "$PR" --json statusCheckRollup -q \
+    '[.statusCheckRollup[].conclusion] | unique | join(",")')
+  case "$status" in
+    *FAILURE*|*CANCELLED*|*TIMED_OUT*) ci_failed=1; break ;;
+    *SUCCESS*) [[ "$status" != *PENDING* ]] && break ;;
+  esac
+  sleep "$POLL"
+done
+```
+
+`required_checks` from config can pin specific check names; otherwise the
+detected branch protection rules are used.
+
+## Merge protocol
+
+```bash
+case "$config.merge.strategy" in
+  squash)  flag="--squash" ;;
+  rebase)  flag="--rebase" ;;
+  merge)   flag="--merge"  ;;
+esac
+delete_flag=""
+[ "$config.merge.delete_branch" = "true" ] && delete_flag="--delete-branch"
+gh pr merge "$PR" $flag $delete_flag
+```
+
+When `config.merge.auto_merge` is true the skill instead enables GitHub
+auto-merge (`gh pr merge --auto $flag`) and exits without polling locally.
+
+## Post-merge dispatch
+
+Each action in `config.post_merge` (or `--post-merge` override) runs in
+order. Built-in types:
+
+- `dispatch_workflow` → `gh workflow run <workflow> -f key=value …`
+- `run_command` → invoke `/sleepwell:<command>` with provided args
+- `shell` → run a shell command (must match `post_merge.allowed_shell`)
+- `none` → no-op
+
+A failure in post-merge does **not** roll back the merge; the skill
+records it under `state.post_merge_errors[]` and finalizes with
+`status = "merged_with_post_merge_errors"`.
+
+## Round termination
+
+A round ends when either:
+
+- Reviewer submits `APPROVE` (no comments at/above `block_on_severity`), or
+- `current_round == max_review_rounds`.
+
+If the cap is hit while comments remain, the skill finalizes
+`status = "review_unresolved"` and leaves the PR unmerged (unless
+`--no-merge` was already implied).
+
+## Failure handling
+
+- Implementer aborts → no PR created; team-state finalized as `aborted_implement`.
+- Review API errors → retry with exponential backoff (3 attempts) before
+  marking the round as `review_error` and stopping.
+- CI timeout → `ci_failed`; PR left open with explanatory comment.
+- Merge conflict during merge → finalize `merge_conflict`; user resolves
+  manually.
+
+## Composition
+
+This skill does not re-implement the loop, the PR creation or the verify
+ritual. It composes the existing sleepwell skills and `gh` CLI calls. New
+behavior should land in `lib/team-workflow.md` first, then be referenced
+from here.


### PR DESCRIPTION
## Summary

Two complementary capabilities that together close the loop on the
"plugin manutenção + entrega ponta-a-ponta" gap:

### 1. Self-heal when plugin cache disappears

When the Claude Code plugin cache (\`~/.claude/plugins/cache/sleepwell/...\`)
is removed (CC update, third-party tool, manual cleanup) while
\`installed_plugins.json\` still references the path, all
\`/sleepwell:*\` commands silently disappear. Recovery requires manual
intervention.

- **\`scripts/restore-plugin-cache.sh\`** — standalone POSIX script that
  works without sleepwell loaded. Re-clones into the expected cache
  path, fixes \`installed_plugins.json\` non-destructively (preserves
  all fields via python json), backs up broken dirs as
  \`<path>.broken.<timestamp>\` for forensics. Args: \`--dry-run\`,
  \`--force\`, \`--verbose\`.
- **\`/sleepwell:sleepwell-doctor --restore-cache\`** — flag that calls
  the script. Doctor output gains a \`cache:\` row.
- **README Recovery section** (EN + PT-BR) with one-liner.

### 2. Multi-agent team workflow

Instrumentalizes the orchestrated PR cycle (implement → branch → PR →
reviewer agent → fixer agent → CI wait → merge → optional post-merge)
as a first-class command + skill.

- **\`commands/sleepwell-team-fix.md\`** — entrypoint command.
- **\`skills/sleepwell-team/SKILL.md\`** — orchestrator skill with
  exact \`gh api\` payloads for line-level review comments and reply
  threads.
- **\`lib/team-workflow.md\`** — authoritative 10-section ritual doc.
- **\`.sleepwell/team.config.example.yaml\`** — template covering
  \`review\`, \`fix\`, \`ci\`, \`merge\`, \`post_merge\`. \`post_merge\`
  is **flexible**: \`none\`, \`dispatch_workflow\`, \`run_command\`,
  \`shell\` — adapts to teams without a release step.
- **README "Team workflow" section** (EN + PT-BR).
- **\`/sleepwell:sleepwell --with-team\`** flag chains the loop into
  team-fix automatically.

The 4 agents:

| Agent | Role |
|---|---|
| Implementer | runs the standard sleepwell loop until done |
| Reviewer | line-level comments via \`POST /pulls/:n/reviews\` |
| Fixer | applies fixes + replies on threads |
| CI-Watcher | polls \`gh pr checks --watch\` until green or timeout |

## Changes

6 atomic commits (\`b6c0feb\`, \`d73bded\`, \`c9a704b\`, \`637220b\`, \`21e5fcc\`, \`93b4099\`).

## Test plan

- [ ] CI green (ShellCheck on the new script, plugin manifest validation, Rust untouched).
- [ ] \`bash -n scripts/restore-plugin-cache.sh\` ok.
- [ ] \`python3 -c "import yaml; yaml.safe_load(open('.sleepwell/team.config.example.yaml'))"\` ok.
- [ ] \`scripts/restore-plugin-cache.sh --dry-run --verbose\` against a healthy cache returns "no action needed".
- [ ] Frontmatter of new commands/skills parses.
- [ ] This PR itself is being processed by the team workflow we're shipping (dogfood).

## Dogfood

This PR is being shipped using the workflow described inside it:
implementer agent, reviewer agent, fixer agent, CI watcher, merge with
optional release.
