### PR TITLE
fix: Corrige plugin_latest unknown e hooks com path relativo

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -25,7 +25,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "hooks/ensure-helper.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/ensure-helper.sh"
           }
         ]
       },
@@ -33,7 +33,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "hooks/check-update.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/check-update.sh"
           }
         ]
       }
@@ -44,7 +44,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "hooks/block-push.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/block-push.sh"
           }
         ]
       },
@@ -53,7 +53,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "hooks/scope-guard.sh"
+            "command": "${CLAUDE_PLUGIN_ROOT}/hooks/scope-guard.sh"
           }
         ]
       }

--- a/hooks/check-update.sh
+++ b/hooks/check-update.sh
@@ -63,6 +63,25 @@ fi
     latest_helper=$(printf '%s' "$json" | jq -r '[.[] | select(.tag_name | startswith("bin-v"))][0].tag_name // empty' 2>/dev/null || true)
   fi
 
+  # Fallback: plugin tag may not exist (repo only tags helper as bin-v*).
+  # Read .claude-plugin/plugin.json from default branch via raw GitHub.
+  if [ -z "$latest_plugin" ]; then
+    raw_json=""
+    if command -v gh >/dev/null 2>&1; then
+      raw_json=$(timeout 8 gh api "repos/$REPO_SLUG/contents/.claude-plugin/plugin.json" --jq '.content' 2>/dev/null | base64 -d 2>/dev/null || true)
+    fi
+    if [ -z "$raw_json" ] && command -v curl >/dev/null 2>&1; then
+      for branch in main master; do
+        raw_json=$(curl -fsSL --max-time 8 "https://raw.githubusercontent.com/$REPO_SLUG/$branch/.claude-plugin/plugin.json" 2>/dev/null || echo "")
+        [ -n "$raw_json" ] && break
+      done
+    fi
+    if [ -n "$raw_json" ]; then
+      remote_ver=$(printf '%s' "$raw_json" | jq -r '.version // empty' 2>/dev/null || true)
+      [ -n "$remote_ver" ] && latest_plugin="v$remote_ver"
+    fi
+  fi
+
   # Strip prefixes for comparison.
   lp=${latest_plugin#v}
   lh=${latest_helper#bin-v}


### PR DESCRIPTION
## Summary

- Resolve dois bugs reportados: `plugin_latest: unknown` em `/sleepwell:sleepwell-update` e `hooks/block-push.sh: No such file or directory` quando CWD não é a raiz do plugin.

## Changes

- `hooks/check-update.sh`: fallback que lê `.claude-plugin/plugin.json` do branch default via `gh api contents` (com base64 -d) ou `raw.githubusercontent.com` quando o repo não publica tags `v*`. Mantém detecção de `bin-v*` para o helper.
- `.claude-plugin/plugin.json`: paths dos hooks agora usam `${CLAUDE_PLUGIN_ROOT}/hooks/...` em vez de relativos, garantindo execução correta independente do CWD.

## Test plan

- [x] `bash hooks/check-update.sh && cat ~/.cache/sleepwell/update.json` → retorna `plugin_latest: v0.7.1` (em vez de `unknown`)
- [ ] CI verde (Rust matrix + plugin-manifest + ShellCheck)
- [ ] Após merge, sessão nova não exibe mais `hooks/block-push.sh: No such file or directory`