### PR TITLE
docs: Regra de uso obrigatório de AskUserQuestion

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,37 @@
+# CLAUDE.md — sleepwell
+
+Project-specific instructions for Claude Code agents working inside this repo.
+
+## Asking the user questions
+
+**Always use the `AskUserQuestion` tool when you need a decision, clarification,
+or preference from the user.** Never ask via plain text in the chat when the
+question expects a discrete answer.
+
+This applies to:
+
+- Disambiguating intent (e.g. "did you mean A or B?")
+- Choosing between implementation strategies
+- Confirming destructive or hard-to-reverse actions
+- Selecting target scope (which repo, which branch, which env)
+
+Why: structured questions with explicit options are auditable, parseable by
+downstream skills (`sleepwell-team`, `sleepwell-meta`), and avoid ambiguous
+free-text replies that derail multi-agent runs.
+
+Plain text questions are only acceptable when:
+
+- The answer is genuinely free-form prose (e.g. "describe the bug").
+- You are inside a sub-agent that does not have `AskUserQuestion` available —
+  in that case, return control to the orchestrator and let it ask.
+
+This rule is also reflected in `lib/team-workflow.md` §11 and the
+`sleepwell-team` SKILL.md.
+
+## Other repo conventions
+
+- Conventional Commits + Jira format from the user's global rules
+- Branches: `<type>/<slug_snake_case>` (no Jira card for this repo's internal work)
+- Plugin hook paths must use `${CLAUDE_PLUGIN_ROOT}/...`, never relative
+- Cross-platform helper binary lives in `bin/sleepwell-helper/` (Rust)
+- Release process: `bump-version.yml` → tag `vX.Y.Z` (plugin) + `bin-vX.Y.Z` (helper)

--- a/lib/team-workflow.md
+++ b/lib/team-workflow.md
@@ -312,3 +312,30 @@ the next layer. Validation:
 
 The team skill validates the merged config at startup and aborts with
 a descriptive error before any agent is dispatched.
+
+## §11. User questions — `AskUserQuestion` only
+
+Whenever any agent in the team workflow needs a decision from the
+operator (intent ambiguity, target repo, post-merge action override,
+conflict resolution), it **must** use Claude Code's `AskUserQuestion`
+tool. Plain-text prompts in the chat are not allowed for discrete
+choices — they are not parseable by the orchestrator and break audit
+trails persisted in `team-state.json`.
+
+Rules:
+
+- The Implementer, Reviewer, Fixer, and CI-Watcher all surface
+  questions through `AskUserQuestion`. Sub-agents that lack the tool
+  must return control to the orchestrator with a structured request,
+  and the orchestrator asks.
+- The list of options must be exhaustive enough that the user rarely
+  needs to pick "Other"; "Other" is reserved for genuinely free-form
+  answers.
+- Confirming destructive actions (force-push, merge with red CI,
+  deleting a backup) always uses `AskUserQuestion` with the
+  destructive option clearly labeled.
+- The recorded answer is written to `team-state.user_decisions[]`
+  with `{question, answer, asked_at, agent}` for replay.
+
+Plain text is acceptable only when the answer is intrinsically
+free-form prose (e.g. "describe the bug to debug").

--- a/skills/sleepwell-team/SKILL.md
+++ b/skills/sleepwell-team/SKILL.md
@@ -11,6 +11,10 @@ Activated by `/sleepwell:sleepwell-team-fix "<intent>" [opts]`.
 > **Authoritative flow:** `lib/team-workflow.md`. This skill **implements** the
 > ritual described there — when in doubt, the lib file wins.
 
+> **User questions:** any clarification, confirmation, or decision asked of the
+> operator MUST use the `AskUserQuestion` tool — never plain text. See
+> `lib/team-workflow.md` §11.
+
 ## Architecture
 
 Four coordinated agents, plus an optional fifth:


### PR DESCRIPTION
## Summary

- Documenta que toda pergunta ao operador feita por agentes do sleepwell deve usar a ferramenta `AskUserQuestion` do Claude Code, nunca texto livre.

## Changes

- `CLAUDE.md` (novo): regra de projeto + convenções gerais
- `lib/team-workflow.md`: §11 com a especificação detalhada (escopo, exceções, persistência em `team-state.user_decisions[]`)
- `skills/sleepwell-team/SKILL.md`: callout no topo apontando para §11

## Test plan

- [x] Commit limpo, sem mudança de runtime
- [ ] Próximo run do team workflow respeita a regra (validado em uso)