### PR TITLE
feat: Adiciona changelog automático no bump-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -161,6 +161,66 @@ jobs:
             (cd bin/sleepwell-helper && cargo update -p sleepwell-helper --precise "$NEW" 2>/dev/null || cargo generate-lockfile)
           fi
 
+      - name: Generate changelog section
+        if: ${{ inputs.dry_run == false }}
+        id: changelog
+        env:
+          NEW: ${{ steps.compute.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          # Determine "from" reference: previous v* plugin tag if any,
+          # otherwise fall back to the previous bin-v* tag so the very
+          # first run after bootstrap still produces a meaningful range.
+          from=$(git tag --list 'v*' --sort=-v:refname \
+                 | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+-' | head -1 || true)
+          if [ -z "$from" ]; then
+            from=$(git tag --list 'bin-v*' --sort=-v:refname | sed -n '2p' || true)
+          fi
+
+          chmod +x scripts/generate-changelog.sh
+          section=$(scripts/generate-changelog.sh "$NEW" "$from" HEAD)
+
+          # Save the section as both a step output and a file for the
+          # release step. Use the heredoc form to handle multiline.
+          {
+            echo 'body<<CHANGELOG_EOF'
+            printf '%s\n' "$section"
+            echo 'CHANGELOG_EOF'
+          } >> "$GITHUB_OUTPUT"
+
+          mkdir -p .ci-tmp
+          printf '%s\n' "$section" > .ci-tmp/release-body.md
+
+          # Prepend new section to CHANGELOG.md (idempotent — replace any
+          # pre-existing v${NEW} section if rerun manually).
+          touch CHANGELOG.md
+          python3 - "$NEW" .ci-tmp/release-body.md CHANGELOG.md <<'PY'
+          import re, sys, pathlib
+          new_ver, body_path, changelog_path = sys.argv[1], sys.argv[2], sys.argv[3]
+          body = pathlib.Path(body_path).read_text()
+          changelog = pathlib.Path(changelog_path)
+          src = changelog.read_text() if changelog.exists() else ""
+
+          # Remove any existing block for this exact version.
+          pattern = re.compile(
+              rf'(?ms)^## v{re.escape(new_ver)}\s+—.*?(?=^## v|\Z)'
+          )
+          src = pattern.sub("", src)
+
+          if src.lstrip().startswith("# Changelog"):
+              # Insert after header block.
+              parts = re.split(r'(?m)(?=^## v)', src, maxsplit=1)
+              header = parts[0].rstrip() + "\n\n"
+              tail = parts[1] if len(parts) > 1 else ""
+              out = header + body.rstrip() + "\n\n" + tail
+          else:
+              header = "# Changelog\n\nAll notable changes to **sleepwell** are documented here.\n\n"
+              out = header + body.rstrip() + "\n\n" + src.lstrip()
+
+          changelog.write_text(out)
+          print(f"changelog updated for v{new_ver}")
+          PY
+
       - name: Commit and tag
         if: ${{ inputs.dry_run == false }}
         env:
@@ -172,7 +232,8 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
 
           git add bin/sleepwell-helper/Cargo.toml bin/sleepwell-helper/Cargo.lock \
-                  .claude-plugin/plugin.json .claude-plugin/marketplace.json 2>/dev/null || true
+                  .claude-plugin/plugin.json .claude-plugin/marketplace.json \
+                  CHANGELOG.md 2>/dev/null || true
 
           if git diff --cached --quiet; then
             echo "::warning::no version files changed (already at $NEW?)"
@@ -183,12 +244,31 @@ jobs:
           Tag ${TAG} will fire the release workflow to build and publish artifacts."
           fi
 
-          git tag -a "$TAG" -m "sleepwell-helper v${NEW}"
+          # Two tags: v* for the plugin (changelog target), bin-v* for the
+          # helper binary (release.yml target).
+          git tag -a "v${NEW}" -m "sleepwell v${NEW}"
+          git tag -a "$TAG"   -m "sleepwell-helper v${NEW}"
 
           git push origin HEAD:main
+          git push origin "v${NEW}"
           git push origin "$TAG"
 
-      - name: Trigger release workflow for the new tag
+      - name: Create plugin GitHub Release
+        if: ${{ inputs.dry_run == false }}
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NEW: ${{ steps.compute.outputs.new_version }}
+        run: |
+          set -euo pipefail
+          # Wait for the tag to be visible to the API before creating the release.
+          sleep 5
+          gh release create "v${NEW}" \
+            --title "sleepwell v${NEW}" \
+            --notes-file .ci-tmp/release-body.md \
+            -R "${{ github.repository }}"
+          echo "Created plugin release v${NEW}"
+
+      - name: Trigger helper release workflow for the new tag
         if: ${{ inputs.dry_run == false }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -199,8 +279,7 @@ jobs:
           # (anti-loop protection). Workflow_dispatch is the documented
           # exception, so we kick release.yml explicitly with the new tag
           # as ref. The release job sees github.ref=refs/tags/<tag> and
-          # uploads artifacts to the matching release.
-          # Wait briefly so the tag is fully visible to the API.
+          # uploads helper binaries to the matching bin-v* release.
           sleep 5
           gh workflow run release.yml --ref "$TAG" -R "${{ github.repository }}"
           echo "Dispatched release.yml for $TAG"
@@ -215,6 +294,13 @@ jobs:
             echo "| Bump type | \`${{ inputs.bump }}\` |"
             echo "| Current   | \`${{ steps.current.outputs.current }}\` (from ${{ steps.current.outputs.source }}) |"
             echo "| New       | \`${{ steps.compute.outputs.new_version }}\` |"
-            echo "| Tag       | \`${{ steps.compute.outputs.new_tag }}\` |"
-            echo "| Dry run   | \`${{ inputs.dry_run }}\` |"
+            echo "| Helper tag | \`${{ steps.compute.outputs.new_tag }}\` |"
+            echo "| Plugin tag | \`v${{ steps.compute.outputs.new_version }}\` |"
+            echo "| Dry run    | \`${{ inputs.dry_run }}\` |"
+            if [ -f .ci-tmp/release-body.md ]; then
+              echo ""
+              echo "### Changelog"
+              echo ""
+              cat .ci-tmp/release-body.md
+            fi
           } >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,66 @@
+# Changelog
+
+All notable changes to **sleepwell** (the Claude Code plugin) are documented here.
+Format follows [Keep a Changelog](https://keepachangelog.com/) and
+[Conventional Commits](https://www.conventionalcommits.org/).
+
+Each section is generated automatically by `scripts/generate-changelog.sh` during
+the `Bump version & release` workflow. The `bin-v*` (helper binary) tags are
+tracked separately on the GitHub Releases page.
+
+## v0.7.2 — 2026-05-04
+
+_Compare: [`bin-v0.7.1…v0.7.2`](https://github.com/FelipeOFF/sleepwell/compare/bin-v0.7.1...v0.7.2)_
+
+### Bug fixes
+
+- Corrige plugin_latest unknown e hooks com path relativo (05778fb)
+
+
+## v0.7.1 — 2026-05-04
+
+_Compare: [`bin-v0.7.0…v0.7.1`](https://github.com/FelipeOFF/sleepwell/compare/bin-v0.7.0...v0.7.1)_
+
+### Features
+
+- lib/team-workflow.md + config example YAML (21e5fcc)
+- skill sleepwell-team + command sleepwell-team-fix (637220b)
+- --restore-cache flag e cache integrity check (d73bded)
+- scripts/restore-plugin-cache.sh standalone (b6c0feb)
+
+### Bug fixes
+
+- shellcheck SC2034+SC2155 em restore-plugin-cache.sh (2376d41)
+- alinhar block_on_severity + interação restore-cache×reinstall (b71dde7)
+- gh api/checks corrigidos + edge case no-checks (a6d0ce5)
+- atomic write + parametrizar repo + cleanup de backups (3c34842)
+- bump-version precisa de actions:write para gh workflow run (4f55fa0)
+
+### Documentation
+
+- README + integração com /sleepwell:sleepwell --with-team (93b4099)
+- README Recovery section EN+PT-BR (c9a704b)
+
+
+## v0.7.0 — 2026-05-04
+
+_Compare: [`bin-v0.6.0…v0.7.0`](https://github.com/FelipeOFF/sleepwell/compare/bin-v0.6.0...v0.7.0)_
+
+### Features
+
+- registra check-update no plugin.json e plugando ensure-helper (7903e7a)
+- hooks/check-update.sh + commands/sleepwell-update.md (e0834b2)
+
+### Bug fixes
+
+- Aplica gaps do review do update check (16d3187)
+- bump-version dispara release.yml apos criar a tag (735d808)
+
+### Documentation
+
+- Clarifica fluxo do /sleepwell-update e documenta opt-out (6912439)
+
+### Other
+
+- docs+sec: README updates section + Tab tip + auditoria eval/read (c8851bf)
+

--- a/scripts/generate-changelog.sh
+++ b/scripts/generate-changelog.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+# generate-changelog.sh — render a Conventional Commits changelog section.
+#
+# Usage:
+#   scripts/generate-changelog.sh <new_version> [from_ref] [to_ref]
+#
+# Defaults:
+#   from_ref → previous v* plugin tag (or empty if none)
+#   to_ref   → HEAD
+#
+# Emits markdown to stdout suitable for prepending to CHANGELOG.md and
+# also for use as a GitHub Release body. Compatible with bash 3.2+.
+set -euo pipefail
+
+NEW="${1:?missing new version (e.g. 0.7.3)}"
+FROM="${2:-}"
+TO="${3:-HEAD}"
+
+if [ -z "$FROM" ]; then
+  FROM=$(git tag --list 'v*' --sort=-v:refname \
+         | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+-' \
+         | head -1 || true)
+fi
+
+if [ -z "$FROM" ]; then
+  RANGE="$TO"
+else
+  RANGE="$FROM..$TO"
+fi
+
+DATE=$(date -u +%Y-%m-%d)
+
+# Output buckets stored in tempfiles to stay portable across bash versions.
+TMPDIR_OUT=$(mktemp -d 2>/dev/null || mktemp -d -t cl)
+trap 'rm -rf "$TMPDIR_OUT"' EXIT
+
+bucket_label() {
+  case "$1" in
+    feat)     printf '### Features' ;;
+    fix)      printf '### Bug fixes' ;;
+    perf)     printf '### Performance' ;;
+    refactor) printf '### Refactor' ;;
+    docs)     printf '### Documentation' ;;
+    test)     printf '### Tests' ;;
+    build)    printf '### Build' ;;
+    ci)       printf '### CI' ;;
+    chore)    printf '### Chore' ;;
+    style)    printf '### Style' ;;
+    hotfix)   printf '### Hotfix' ;;
+    other)    printf '### Other' ;;
+    *) return 1 ;;
+  esac
+}
+ORDER="feat fix perf refactor docs test build ci chore style hotfix other"
+
+# Process commits via process substitution (POSIX-friendly while read).
+git log "$RANGE" --no-merges --pretty=tformat:'%h%x09%s' \
+  | while IFS=$'\t' read -r sha subject || [ -n "$sha" ]; do
+      [ -z "$sha" ] && continue
+      type=""
+      title="$subject"
+
+      # Match `type(scope)?: subject` (banged or not). Use grep -E for portability.
+      head_part="${subject%%:*}"
+      rest_part="${subject#*: }"
+      cleaned_head=$(printf '%s' "$head_part" | sed -E 's/!$//' | sed -E 's/\(.+\)$//')
+      if printf '%s' "$cleaned_head" | grep -Eq '^[a-z]+$' && [ "$head_part" != "$subject" ]; then
+        type="$cleaned_head"
+        title="$rest_part"
+      fi
+
+      # Skip release chores entirely — they are noise.
+      case "$subject" in
+        chore\(release\)*) continue ;;
+      esac
+
+      if [ -n "$type" ] && bucket_label "$type" >/dev/null 2>&1; then
+        printf -- '- %s (%s)\n' "$title" "$sha" >> "$TMPDIR_OUT/$type"
+      else
+        printf -- '- %s (%s)\n' "$subject" "$sha" >> "$TMPDIR_OUT/other"
+      fi
+    done
+
+REPO_URL=$(git config --get remote.origin.url 2>/dev/null \
+  | sed -E 's#(git@|https://)github.com[:/]([^/]+)/([^/.]+)(\.git)?#https://github.com/\2/\3#' || true)
+
+{
+  printf '## v%s — %s\n\n' "$NEW" "$DATE"
+  if [ -n "$FROM" ] && [ -n "$REPO_URL" ]; then
+    printf '_Compare: [`%s…v%s`](%s/compare/%s...v%s)_\n\n' \
+      "$FROM" "$NEW" "$REPO_URL" "$FROM" "$NEW"
+  fi
+
+  emitted=0
+  for type in $ORDER; do
+    if [ -s "$TMPDIR_OUT/$type" ]; then
+      bucket_label "$type"
+      printf '\n\n'
+      cat "$TMPDIR_OUT/$type"
+      printf '\n'
+      emitted=1
+    fi
+  done
+
+  if [ "$emitted" = "0" ]; then
+    if [ -n "$FROM" ]; then
+      printf '_No user-facing changes since %s._\n\n' "$FROM"
+    else
+      printf '_Initial release._\n\n'
+    fi
+  fi
+}


### PR DESCRIPTION
## Summary

- Gera changelog automaticamente a partir de Conventional Commits a cada bump de versão e popula em `CHANGELOG.md` + GitHub Release notes.

## Changes

- `scripts/generate-changelog.sh` (novo): renderiza markdown agrupado por tipo (feat/fix/perf/refactor/docs/test/build/ci/chore/style/hotfix) entre duas refs git. Compatível com bash 3.2+.
- `CHANGELOG.md` (novo): bootstrap com versões 0.7.0/0.7.1/0.7.2 geradas pelo script.
- `.github/workflows/bump-version.yml`: novo step "Generate changelog section" antes do commit. Cria duas tags (`v*` plugin + `bin-v*` helper). Publica GitHub Release `v<X.Y.Z>` com body do changelog. Mantém dispatch do `release.yml` para os binários do helper.

## Decisões de design

Confirmadas via `AskUserQuestion`:

- **Destino:** ambos — `CHANGELOG.md` versionado + Release notes
- **Filtro:** apenas Conventional Commits (chore/release ignorados como ruído)
- **Escopo:** plugin (`v*`) — helper (`bin-v*`) mantém release próprio com binários

## Test plan

- [x] `bash scripts/generate-changelog.sh 0.7.3 92a4a40 HEAD` localmente — agrupa fix + docs corretamente
- [x] Bootstrap do `CHANGELOG.md` reflete histórico real
- [ ] CI verde (Rust matrix + ShellCheck no novo script + plugin-manifest)
- [ ] Após merge, próximo `gh workflow run bump-version.yml -f bump=patch` cria `v0.7.3`, atualiza `CHANGELOG.md` com a seção de fix do PR atual e publica Release com o body