### PR TITLE
fix: Corrige baseline do changelog no bump-version

### DIFF
--- a/.github/workflows/bump-version.yml
+++ b/.github/workflows/bump-version.yml
@@ -174,7 +174,10 @@ jobs:
           from=$(git tag --list 'v*' --sort=-v:refname \
                  | grep -vE '^v[0-9]+\.[0-9]+\.[0-9]+-' | head -1 || true)
           if [ -z "$from" ]; then
-            from=$(git tag --list 'bin-v*' --sort=-v:refname | sed -n '2p' || true)
+            # No plugin v* tag yet — fall back to the most recent helper
+            # tag. The new bin-v* tag is only created in a later step,
+            # so head -1 gives the previous bump's baseline correctly.
+            from=$(git tag --list 'bin-v*' --sort=-v:refname | head -1 || true)
           fi
 
           chmod +x scripts/generate-changelog.sh


### PR DESCRIPTION
## Summary

- Bug encontrado no v0.7.3: changelog incluiu o fix do PR #41 que já tinha sido publicado no v0.7.2.
- Causa: fallback usava `sed -n '2p'` (assume que a nova `bin-v*` já existe), mas a tag é criada num step posterior.
- Fix: trocar por `head -1` — pega a tag mais recente existente, que é o baseline correto.

## Test plan

- [ ] CI verde
- [ ] Próximo bump (`v0.7.4`) gera changelog com escopo correto: apenas o commit deste PR