### PR TITLE
feat: Plugin self-update via script (mirrors GSD approach)

### DIFF
--- a/commands/sleepwell-update.md
+++ b/commands/sleepwell-update.md
@@ -14,20 +14,20 @@ SessionStart `check-update.sh` hook).
 
 - `--check` (default if no arg): print what is available without
   applying.
-- `--apply`: download the helper binary update automatically (via
-  `scripts/install-helper.sh`) and **print to the user** the
-  instruction to run `/plugin update sleepwell@sleepwell` followed by
-  `/reload-plugins`. The plugin update itself is **not** executed by
-  this command — only the helper binary download is automatic.
-- `--plugin-only`: print plugin update guidance only.
-- `--helper-only`: download/install helper binary only.
+- `--apply`: install **both** the helper binary AND the plugin cache
+  automatically. After applying, the user only has to run
+  `/reload-plugins` (or restart Claude Code) for the new commands and
+  skills to be picked up — Claude Code does not expose a tool that
+  can run `/reload-plugins` from a command body.
+- `--plugin-only`: install plugin cache only (no helper change).
+- `--helper-only`: install helper binary only (no plugin change).
 
 ## Output (example, --check)
 
 | Component | Installed | Latest | Update? |
 |---|---|---|---|
-| sleepwell plugin | v0.6.1 | v0.7.0 | yes — run /plugin update sleepwell@sleepwell |
-| sleepwell-helper | bin-v0.6.0 | bin-v0.6.1 | yes — run with --apply or --helper-only |
+| sleepwell plugin | 0.7.0 | v0.7.3 | yes — run with --apply or --plugin-only |
+| sleepwell-helper | bin-v0.6.0 | bin-v0.7.3 | yes — run with --apply or --helper-only |
 
 If no updates, prints "Up-to-date" with both versions.
 
@@ -37,28 +37,36 @@ If no updates, prints "Up-to-date" with both versions.
    SessionStart `check-update.sh` hook (refreshed every 24h).
 2. If cache is missing or stale, refreshes inline (synchronous, ~2s).
 3. With `--apply`:
-   - **Helper binary update is automatic**: invokes
-     `bash scripts/install-helper.sh --version <tag>`.
-   - **Plugin update is an instruction**: this command prints to the
-     user the message to run `/plugin update sleepwell@sleepwell` and
-     then `/reload-plugins` (or restart Claude Code) manually. Slash
-     commands cannot invoke `/plugin update` from their body.
+   - **Helper binary** → `bash $CLAUDE_PLUGIN_ROOT/scripts/install-helper.sh --version <tag>`
+   - **Plugin cache** → `bash $CLAUDE_PLUGIN_ROOT/scripts/update-plugin-cache.sh --version <tag>`
+     - Clones the new release into `~/.claude/plugins/cache/sleepwell/sleepwell/<X.Y.Z>`,
+       atomically rewrites `installed_plugins.json` to point to it, and
+       prunes older sibling cache directories (keeps `.broken.*`
+       backups intact).
+   - **Final step** is reload — the command prints the reminder to
+     run `/reload-plugins` (or restart Claude Code).
 
 ## Execution flow (for the agent)
 
 1. Read `~/.cache/sleepwell/update.json`. If missing or older than
-   `SLEEPWELL_UPDATE_TTL` seconds, run `bash hooks/check-update.sh`
-   synchronously and re-read after ~3s.
+   `SLEEPWELL_UPDATE_TTL` seconds, run
+   `bash $CLAUDE_PLUGIN_ROOT/hooks/check-update.sh` synchronously and
+   re-read after ~3s.
 2. Parse `plugin_update_available` and `helper_update_available`.
 3. Print a status table (Component | Installed | Latest | Update?).
 4. If `--apply` or `--helper-only` and helper update is available:
-   - Run `bash scripts/install-helper.sh --version "$helper_latest"`.
+   - Run `bash $CLAUDE_PLUGIN_ROOT/scripts/install-helper.sh --version "$helper_latest"`.
    - Verify with `sleepwell-helper --version`.
 5. If `--apply` or `--plugin-only` and plugin update is available:
-   - **Print to user** (do not execute): "To complete the plugin
-     update, run `/plugin update sleepwell@sleepwell` and then
-     `/reload-plugins` (or restart Claude Code)."
+   - Run `bash $CLAUDE_PLUGIN_ROOT/scripts/update-plugin-cache.sh --version "$plugin_latest"`.
+   - Print: "Plugin cache updated to <ver>. Run `/reload-plugins` (or
+     restart Claude Code) to load the new commands and skills."
 6. If no updates: print "Up-to-date".
+
+> **Note on `${CLAUDE_PLUGIN_ROOT}`:** Claude Code injects this env
+> var into command/hook execution contexts. When the agent runs the
+> scripts, prefer the env-var path — falls back to discovery via
+> `installed_plugins.json` if unset.
 
 ## Escape hatch
 
@@ -73,12 +81,22 @@ who never want the optional helper installed):
 mkdir -p ~/.config/sleepwell && touch ~/.config/sleepwell/no-helper
 ```
 
+To roll back a plugin upgrade after `--apply`, reuse the recovery
+flow:
+
+```bash
+bash $CLAUDE_PLUGIN_ROOT/scripts/update-plugin-cache.sh --version v<previous>
+```
+
 ## Notes
 
 - Cache TTL configurable via `SLEEPWELL_UPDATE_TTL` (seconds).
-- Repo can be overridden via `SLEEPWELL_UPDATE_REPO=<owner>/<name>`;
-  otherwise it is parsed from `.claude-plugin/plugin.json` `.repository`.
+- Repo can be overridden via `SLEEPWELL_UPDATE_REPO=<owner>/<name>`
+  (or `SLEEPWELL_REPO=<owner>/<name>` for the install/update scripts);
+  otherwise it is parsed from `.claude-plugin/plugin.json` `.repository`
+  or inferred from the `installed_plugins.json` key.
 - The helper download uses the same flow as the bootstrap install
   (GitHub Releases for `bin-v*` tags, platform auto-detection).
-- Plugin updates require Claude Code to reload plugins
-  (`/reload-plugins` or restart) — this command will not do it for you.
+- Plugin updates still require `/reload-plugins` (or a Claude Code
+  restart) — `/plugin` slash commands cannot be triggered from inside
+  another command body.

--- a/scripts/update-plugin-cache.sh
+++ b/scripts/update-plugin-cache.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# update-plugin-cache.sh — self-update for the sleepwell plugin cache.
+#
+# Mirrors what `/plugin update sleepwell@sleepwell` would do, but as a
+# regular shell command — so an agent (Claude Code, Codex, etc.) can
+# upgrade the plugin without the user having to type a slash command.
+#
+# Usage:
+#   bash scripts/update-plugin-cache.sh                 # resolve "latest" tag, install
+#   bash scripts/update-plugin-cache.sh --version v0.7.3
+#   bash scripts/update-plugin-cache.sh --version latest --dry-run
+#   bash scripts/update-plugin-cache.sh --force         # re-clone even if same version
+#
+# Repo override: SLEEPWELL_REPO=owner/name (default FelipeOFF/sleepwell).
+#
+# After a successful update the user must run /reload-plugins (or
+# restart Claude Code) for the new commands and skills to be picked up
+# — this script never spawns Claude Code itself.
+#
+# Requires: bash, git, python3, and either gh or curl for tag resolution.
+set -euo pipefail
+
+PLUGINS_JSON="${HOME}/.claude/plugins/installed_plugins.json"
+TARGET_VERSION="latest"
+DRY_RUN=0
+FORCE=0
+VERBOSE=0
+SLEEPWELL_REPO="${SLEEPWELL_REPO:-}"
+DEFAULT_REPO="FelipeOFF/sleepwell"
+
+log()  { echo "[sleepwell-update] $*" >&2; }
+vlog() { [ "$VERBOSE" = "1" ] && echo "[sleepwell-update] (debug) $*" >&2 || true; }
+err()  { echo "[sleepwell-update] error: $*" >&2; exit 1; }
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --version) TARGET_VERSION="$2"; shift 2 ;;
+    --dry-run) DRY_RUN=1; shift ;;
+    --force)   FORCE=1;   shift ;;
+    --verbose) VERBOSE=1; shift ;;
+    --repo)    SLEEPWELL_REPO="$2"; shift 2 ;;
+    -h|--help) sed -n '2,20p' "$0"; exit 0 ;;
+    *) err "unknown arg: $1" ;;
+  esac
+done
+
+command -v git     >/dev/null 2>&1 || err "git not found in PATH"
+command -v python3 >/dev/null 2>&1 || err "python3 not found in PATH"
+[ -f "$PLUGINS_JSON" ] || err "installed_plugins.json not found at $PLUGINS_JSON"
+
+# Workspace for python helpers — avoids heredocs-in-$() issues on bash 3.2.
+WORK="$(mktemp -d)"
+trap 'rm -rf "$WORK"' EXIT
+
+cat > "$WORK/infer_repo.py" <<'PY'
+import json, sys, re
+try:
+    with open(sys.argv[1]) as f:
+        d = json.load(f)
+except Exception:
+    sys.exit(0)
+for key in (d.get("plugins") or {}).keys():
+    m = re.match(r"^sleepwell@([A-Za-z0-9_.-]+(?:/[A-Za-z0-9_.-]+)?)$", key)
+    if not m:
+        continue
+    val = m.group(1)
+    # Skip marketplace-only keys (e.g. "sleepwell@sleepwell") that
+    # carry no owner/repo info — fall back to default.
+    if "/" not in val:
+        continue
+    print(val); break
+PY
+
+cat > "$WORK/dump_entry.py" <<'PY'
+import json, sys
+with open(sys.argv[1]) as f:
+    d = json.load(f)
+for key, arr in (d.get("plugins") or {}).items():
+    if not key.startswith("sleepwell@"):
+        continue
+    for entry in arr:
+        print(key)
+        print(entry.get("installPath", ""))
+        print(entry.get("version", ""))
+        print(entry.get("gitCommitSha", ""))
+        sys.exit(0)
+PY
+
+cat > "$WORK/update_entry.py" <<'PY'
+import json, os, sys, tempfile, time
+path, key, new_path, new_ver, new_sha = sys.argv[1:]
+with open(path) as f:
+    d = json.load(f)
+arr = d["plugins"][key]
+entry = arr[0]
+entry["installPath"] = new_path
+entry["version"] = new_ver
+entry["gitCommitSha"] = new_sha
+entry["lastUpdated"] = time.strftime("%Y-%m-%dT%H:%M:%S.000Z", time.gmtime())
+fd, tmp = tempfile.mkstemp(prefix=".installed_plugins.", dir=os.path.dirname(path))
+try:
+    with os.fdopen(fd, "w") as f:
+        json.dump(d, f, indent=2)
+        f.write("\n")
+    os.replace(tmp, path)
+except Exception:
+    os.unlink(tmp)
+    raise
+print("updated entry for", key)
+PY
+
+cat > "$WORK/parse_latest.py" <<'PY'
+import json, sys
+try:
+    d = json.load(sys.stdin)
+except Exception:
+    sys.exit(0)
+for r in d:
+    t = r.get("tag_name", "")
+    if t.startswith("v") and not t.startswith("bin-") and not r.get("draft"):
+        print(t); break
+PY
+
+# Resolve repo slug.
+if [ -n "$SLEEPWELL_REPO" ]; then
+  REPO_SLUG="$(echo "$SLEEPWELL_REPO" | sed -E 's#^https?://github.com/##; s#\.git$##')"
+else
+  REPO_SLUG="$(python3 "$WORK/infer_repo.py" "$PLUGINS_JSON" || true)"
+  [ -z "$REPO_SLUG" ] && REPO_SLUG="$DEFAULT_REPO"
+fi
+REPO_URL="https://github.com/${REPO_SLUG}.git"
+log "using repo: $REPO_SLUG"
+
+# Resolve target tag.
+if [ "$TARGET_VERSION" = "latest" ]; then
+  TAG=""
+  if command -v gh >/dev/null 2>&1; then
+    TAG="$(gh api "repos/$REPO_SLUG/releases" \
+            --jq '[.[] | select(.draft | not) | select(.tag_name | startswith("v")) | select(.tag_name | startswith("bin-") | not)][0].tag_name // empty' \
+            2>/dev/null || true)"
+  fi
+  if [ -z "$TAG" ] && command -v curl >/dev/null 2>&1; then
+    JSON_RAW="$(curl -fsSL --max-time 8 "https://api.github.com/repos/$REPO_SLUG/releases" 2>/dev/null || echo '[]')"
+    TAG="$(printf '%s' "$JSON_RAW" | python3 "$WORK/parse_latest.py" 2>/dev/null || true)"
+  fi
+  [ -n "$TAG" ] || err "could not resolve latest v* tag from $REPO_SLUG"
+else
+  case "$TARGET_VERSION" in v*) TAG="$TARGET_VERSION" ;; *) TAG="v$TARGET_VERSION" ;; esac
+fi
+
+NEW_VER="${TAG#v}"
+log "target version: $NEW_VER ($TAG)"
+
+# Read current entry (4-line dump: key, installPath, version, sha).
+DUMP="$(python3 "$WORK/dump_entry.py" "$PLUGINS_JSON")"
+[ -z "$DUMP" ] && err "no sleepwell@* entry found in $PLUGINS_JSON"
+
+CURRENT_KEY="$(echo     "$DUMP" | sed -n '1p')"
+CURRENT_PATH="$(echo    "$DUMP" | sed -n '2p')"
+CURRENT_VERSION="$(echo "$DUMP" | sed -n '3p')"
+
+log "currently installed: $CURRENT_VERSION ($CURRENT_PATH)"
+
+if [ "$CURRENT_VERSION" = "$NEW_VER" ] && [ "$FORCE" != "1" ]; then
+  log "already at $NEW_VER — pass --force to re-clone"
+  exit 0
+fi
+
+PARENT_DIR="$(dirname "$CURRENT_PATH")"
+NEW_PATH="$PARENT_DIR/$NEW_VER"
+
+if [ "$DRY_RUN" = "1" ]; then
+  log "[dry-run] would clone $REPO_URL@$TAG → $NEW_PATH"
+  log "[dry-run] would update installed_plugins.json: $CURRENT_VERSION → $NEW_VER"
+  exit 0
+fi
+
+if [ -d "$NEW_PATH" ] && [ "$FORCE" != "1" ]; then
+  vlog "$NEW_PATH already exists, reusing"
+else
+  rm -rf "$NEW_PATH"
+  log "cloning $REPO_URL@$TAG → $NEW_PATH"
+  git clone --depth 1 --branch "$TAG" "$REPO_URL" "$NEW_PATH" >/dev/null 2>&1 \
+    || err "git clone failed for tag $TAG"
+fi
+
+NEW_SHA="$(git -C "$NEW_PATH" rev-parse HEAD)"
+
+python3 "$WORK/update_entry.py" "$PLUGINS_JSON" "$CURRENT_KEY" "$NEW_PATH" "$NEW_VER" "$NEW_SHA"
+
+# Cleanup older sibling cache directories — keep only NEW_VER and any
+# .broken.* backups left by restore-plugin-cache.sh.
+log "cleaning up older cache dirs in $PARENT_DIR"
+for d in "$PARENT_DIR"/*; do
+  [ -d "$d" ] || continue
+  base="$(basename "$d")"
+  case "$base" in
+    "$NEW_VER")  continue ;;
+    *.broken.*)  continue ;;
+    *)
+      vlog "removing $d"
+      rm -rf "$d"
+      ;;
+  esac
+done
+
+# Refresh update cache so next /sleepwell:sleepwell-update sees fresh state.
+rm -f "${XDG_CACHE_HOME:-$HOME/.cache}/sleepwell/update.json"
+
+log "done — installed sleepwell $NEW_VER at $NEW_PATH"
+log "next: run /reload-plugins (or restart Claude Code) to load it"


### PR DESCRIPTION
## Summary

- Adiciona `scripts/update-plugin-cache.sh` para que `/sleepwell:sleepwell-update --apply` consiga atualizar o plugin direto, sem o usuário precisar digitar `/plugin update sleepwell@sleepwell`.
- Estratégia espelhada do GSD: GSD contorna a limitação de slash-commands não invocáveis a partir de outro command sendo um overlay direto (npm install em `~/.claude/`). Sleepwell é plugin de verdade, então replicamos manualmente o que `/plugin update` faria.

## Como funciona

1. Resolve a release alvo (`v<X.Y.Z>` ou `latest`) via `gh api` ou `curl`.
2. Clona em `~/.claude/plugins/cache/sleepwell/sleepwell/<X.Y.Z>`.
3. Atualiza `installed_plugins.json` atomicamente — só os campos `installPath`, `version`, `gitCommitSha`, `lastUpdated`. Preserva tudo o resto.
4. Limpa caches antigos (mantém `.broken.*` deixados pela `restore-plugin-cache.sh`).
5. Limpa `~/.cache/sleepwell/update.json` para forçar refresh.

Único passo manual restante: `/reload-plugins` (a CLI não expõe isso pra agentes).

## Changes

- `scripts/update-plugin-cache.sh` (novo, executável). Compatível com bash 3.2 — scripts Python em tempfiles em vez de heredocs dentro de `$()`.
- `commands/sleepwell-update.md`: `--apply` agora roda o script de plugin junto com o helper. `--plugin-only` ganha semântica concreta (não é mais "instrução"). Documenta `${CLAUDE_PLUGIN_ROOT}` e fluxo de rollback.

## Test plan

- [x] `bash scripts/update-plugin-cache.sh --version v0.7.3 --dry-run` → resolve repo, version, paths corretamente
- [x] `bash scripts/update-plugin-cache.sh --version latest --dry-run` → resolve `v0.7.3` via `gh api`
- [ ] CI verde
- [ ] Após merge: `/sleepwell:sleepwell-update --apply` upgrade real `0.7.2 → 0.7.3` (ou versão mais nova) sem intervenção manual além do `/reload-plugins`